### PR TITLE
Delete outdated info in support-policies.md

### DIFF
--- a/articles/aks/support-policies.md
+++ b/articles/aks/support-policies.md
@@ -103,7 +103,7 @@ Microsoft and you share responsibility for Kubernetes agent nodes where:
 
 ### Customer responsibilities for AKS agent nodes
 
-Microsoft provides patches and new images for your image nodes weekly, but doesn't automatically patch them by default. To keep your agent node OS and runtime components patched, you should keep a regular [node image upgrade](node-image-upgrade.md) schedule or automate it.
+Microsoft provides patches and new images for your image nodes weekly. To keep your agent node OS and runtime components patched, you should keep a regular [node image upgrade](node-image-upgrade.md) schedule or automate it.
 
 Similarly, AKS regularly releases new kubernetes patches and minor versions. These updates can contain security or functionality improvements to Kubernetes. You're responsible to keep your clusters' kubernetes version updated and according to the [AKS Kubernetes Support Version Policy](supported-kubernetes-versions.md).
 


### PR DESCRIPTION
**Proposed change:**
Delete the outdated info, since it does auto upgrade nodeOS image by default.

**Supporting point:**
Try to create AKS in both Azure portal and az-cli w/o modification, the upgrade channel is "nodeOS" by default. 
There is no point of saying "doesn't automatically patch them by default" and this will mislead users. 

```bash
aks=
rG=

az aks create -n ${aks} -g ${rG} --no-wait --no-ssh-key
az aks show -n ${aks} -g ${rG} --query autoUpgradeProfile.nodeOsUpgradeChannel -o tsv
```

**Result:**
```bash
joey [ ~ ]$ az aks show -n ${aks} -g ${rG} --query autoUpgradeProfile.nodeOsUpgradeChannel -o tsv
NodeImage
```
Also from Azure portal:
![image](https://github.com/user-attachments/assets/f2cd4818-eb1c-40b6-9999-e69cdfef9d3f)
