### PR TITLE
Fix wrong service name in limit-egress-traffic.md

### DIFF
--- a/articles/aks/limit-egress-traffic.md
+++ b/articles/aks/limit-egress-traffic.md
@@ -323,7 +323,7 @@ az aks create \
     --api-server-authorized-ip-ranges $FWPUBLIC_IP
     --assign-identity <identity-resource-id> \
     --assign-kubelet-identity <kubelet-identity-resource-id> \
-    --generate-ssh-keys    
+    --generate-ssh-keys
 ```
 
 ---
@@ -389,7 +389,7 @@ To configure inbound connectivity, you need to write a DNAT rule to the Azure Fi
    store-front       LoadBalancer   10.0.89.139    20.39.18.6    80:32271/TCP         10s
    ```
 
-2. Get the service IP using the `kubectl get svc voting-app` command.
+2. Get the service IP using the `kubectl get svc store-front` command.
 
    ```azurecli-interactive
    SERVICE_IP=$(kubectl get svc store-front -o jsonpath='{.status.loadBalancer.ingress[*].ip}')


### PR DESCRIPTION
**Proposed change:** Fix wrong service name.

**Supporting point:**
In the line 389, the service name literally is `store-front`:
https://github.com/MicrosoftDocs/azure-aks-docs/blob/a75aabed22a97f8ef63ae6bb23b4bba92d1d7319/articles/aks/limit-egress-traffic.md?plain=1#L389

Also in Line 395, same:
https://github.com/MicrosoftDocs/azure-aks-docs/blob/a75aabed22a97f8ef63ae6bb23b4bba92d1d7319/articles/aks/limit-egress-traffic.md?plain=1#L395

But the sentence pointing to this service is wrong:
https://github.com/MicrosoftDocs/azure-aks-docs/blob/a75aabed22a97f8ef63ae6bb23b4bba92d1d7319/articles/aks/limit-egress-traffic.md?plain=1#L392