### PR TITLE
Added aad-pod-identity to list of limitations for AKS with Azure CNI powered by Cilium

### DIFF
--- a/articles/aks/azure-cni-powered-by-cilium.md
+++ b/articles/aks/azure-cni-powered-by-cilium.md
@@ -61,7 +61,6 @@ Azure CNI powered by Cilium currently has the following limitations:
 
 * Incompatible with Microsoft Entra pod-managed identities ([aad-pod-identity](https://github.com/Azure/aad-pod-identity)). Use [Microsoft Entra Workload ID](./workload-identity-overview.md) instead.
 
-
 ## Prerequisites
 
 * Azure CLI version 2.48.1 or later. Run `az --version` to see the currently installed version. If you need to install or upgrade, see [Install Azure CLI](/cli/azure/install-azure-cli).

--- a/articles/aks/azure-cni-powered-by-cilium.md
+++ b/articles/aks/azure-cni-powered-by-cilium.md
@@ -59,6 +59,9 @@ Azure CNI powered by Cilium currently has the following limitations:
 
 * Network policies are not applied to pods using host networking (`spec.hostNetwork: true`) because these pods use the host identity instead of having individual identities.
 
+* Incompatible with Microsoft Entra pod-managed identities ([aad-pod-identity](https://github.com/Azure/aad-pod-identity)). Use [Microsoft Entra Workload ID](./workload-identity-overview.md) instead.
+
+
 ## Prerequisites
 
 * Azure CLI version 2.48.1 or later. Run `az --version` to see the currently installed version. If you need to install or upgrade, see [Install Azure CLI](/cli/azure/install-azure-cli).


### PR DESCRIPTION
Pods will be unable to reach the IMDS endpoint when using aad-pod-identity on an AKS cluster w/ Azure CNI powered by Cilium. This is a known limitation that was not documented.

Updated from https://github.com/MicrosoftDocs/azure-docs/pull/123925 with fixed relative links