### PR TITLE
replace hardcoded HUBBLE_VERSION to fetch latest release instead

### DIFF
--- a/articles/aks/advanced-network-observability-cli.md
+++ b/articles/aks/advanced-network-observability-cli.md
@@ -250,7 +250,7 @@ Install the Hubble CLI to access the data it collects using the following comman
 
 ```azurecli-interactive
 # Set environment variables
-export HUBBLE_VERSION=v0.11.0
+export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
 export HUBBLE_ARCH=amd64
 
 #Install Hubble CLI


### PR DESCRIPTION
The previous hardcoded version v0.11.0 is no longer maintained, see [Hubble CLI release reference](https://github.com/cilium/hubble/tree/main?tab=readme-ov-file#releases)

With this change we fetch the latest release of Hubble CLI from the upstream. 