### PR TITLE
aks/use-wasi-node-pools: update the doc to refer to SpinKube

### DIFF
--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -11,10 +11,10 @@ ms.author: schaffererin
 
 # Create WebAssembly System Interface (WASI) node pools in Azure Kubernetes Service (AKS) to run your WebAssembly (Wasm) workload (preview)
 
-[WebAssembly (Wasm)][wasm] is a binary format that is optimized for fast download and maximum execution speed in a Wasm runtime. A Wasm runtime is designed to run on a target architecture and execute Wasm components in a sandbox, isolated from the host computer, at near-native performance. By default, Wasm components can't access resources on the host outside of the sandbox unless it is explicitly allowed, and they can't communicate over sockets to access things like environment variables or HTTP traffic. The [WebAssembly System Interface (WASI)][wasi] standard defines an API for Wasm runtimes to provide access to Wasm components to the environment and resources outside the host using a capabilities model.
+[WebAssembly (Wasm)][wasm] is a binary format that is optimized for fast download and maximum execution speed in a Wasm runtime. A Wasm runtime is designed to run on a target architecture and execute Wasm components in a sandbox, isolated from the host computer, at near-native performance. By default, Wasm components can't access resources on the host outside of the sandbox unless it is explicitly allowed. For example, Wasm components can't communicate over sockets, receive or send HTTP traffic, or even to access things like environment variables without explicit approval. The [WebAssembly System Interface (WASI)][wasi] standard defines an API for Wasm runtimes to provide access to Wasm components to the environment and resources outside the host using a capabilities model.
 
 > [!IMPORTANT]
-> WASI nodepools now use [SpinKube shim][containerd-shim-spin] to run Wasm workloads. Previously, AKS used [Krustlet][krustlet] to allow Wasm modules to be run on Kubernetes. If you are still using Krustlet-based WASI nodepools, you can migrate to containerd shims by creating a new WASI nodepool and migrating your workloads to the new nodepool.
+> WASI nodepools now use [SpinKube containerd shim][containerd-shim-spin] to run Wasm workloads. Previously, AKS used [Krustlet][krustlet] to allow Wasm modules to be run on Kubernetes. If you are still using Krustlet-based WASI nodepools, you can migrate to containerd shims by creating a new WASI nodepool and migrating your workloads to the new nodepool.
 
 ## Before you begin
 
@@ -58,7 +58,7 @@ az provider register --namespace Microsoft.ContainerService
 
 ## Limitations
 
-* Currently, there are only containerd shims available for [spin][spin] applications, which use the [wasmtime][wasmtime] runtime. In addition to wasmtime runtime applications, you can also run containers on Wasm/WASI node pools.
+* Currently, WASI Node Pools only support [Spin][spin] applications which use the [Wasmtime][wasmtime] runtime, and native Linux containers.
 * The SpinKube operator is not supported on Wasm/WASI node pools.
 * The Wasm/WASI node pools can't be used for system node pool.
 * The *os-type* for Wasm/WASI node pools must be Linux.

--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -58,7 +58,7 @@ az provider register --namespace Microsoft.ContainerService
 
 ## Limitations
 
-* Currently, WASI Node Pools only support [Spin][spin] applications which use the [Wasmtime][wasmtime] runtime, and native Linux containers.
+* Currently, WASI Node Pools only support [Spin][spin] applications, which use the [Wasmtime][wasmtime] runtime and native Linux containers.
 * The SpinKube operator is not supported on Wasm/WASI node pools.
 * The Wasm/WASI node pools can't be used for system node pool.
 * The *os-type* for Wasm/WASI node pools must be Linux.

--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -173,7 +173,7 @@ spec:
 ```
 
 > [!NOTE]
-> When developing applications, modules should be build against the `wasm32-wasi` target. For more details, see the [spin][spin] documentation.
+> If you want to know more about how to develop Spin applications, see the [spin][spin] documentation.
 
 Use `kubectl` to run your example deployment:
 

--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -1,6 +1,6 @@
 ---
-title: Create WebAssembly System Interface (WASI) node pools in Azure Kubernetes Service (AKS) to run your WebAssembly (WASM) workload (preview)
-description: Learn how to create a WebAssembly System Interface (WASI) node pool in Azure Kubernetes Service (AKS) to run your WebAssembly (WASM) workload on Kubernetes.
+title: Create WebAssembly System Interface (WASI) node pools in Azure Kubernetes Service (AKS) to run your WebAssembly (Wasm) workload (preview)
+description: Learn how to create a WebAssembly System Interface (WASI) node pool in Azure Kubernetes Service (AKS) to run your WebAssembly (Wasm) workload on Kubernetes.
 ms.topic: how-to
 ms.custom: devx-track-azurecli
 ms.date: 05/17/2023

--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -9,12 +9,12 @@ ms.author: schaffererin
 
 ---
 
-# Create WebAssembly System Interface (WASI) node pools in Azure Kubernetes Service (AKS) to run your WebAssembly (WASM) workload (preview)
+# Create WebAssembly System Interface (WASI) node pools in Azure Kubernetes Service (AKS) to run your WebAssembly (Wasm) workload (preview)
 
-[WebAssembly (WASM)][wasm] is a binary format that is optimized for fast download and maximum execution speed in a WASM runtime. A WASM runtime is designed to run on a target architecture and execute WebAssemblies in a sandbox, isolated from the host computer, at near-native performance. By default, WebAssemblies can't access resources on the host outside of the sandbox unless it is explicitly allowed, and they can't communicate over sockets to access things like environment variables or HTTP traffic. The [WebAssembly System Interface (WASI)][wasi] standard defines an API for WASM runtimes to provide access to WebAssemblies to the environment and resources outside the host using a capabilities model.
+[WebAssembly (Wasm)][wasm] is a binary format that is optimized for fast download and maximum execution speed in a Wasm runtime. A Wasm runtime is designed to run on a target architecture and execute Wasm components in a sandbox, isolated from the host computer, at near-native performance. By default, Wasm components can't access resources on the host outside of the sandbox unless it is explicitly allowed, and they can't communicate over sockets to access things like environment variables or HTTP traffic. The [WebAssembly System Interface (WASI)][wasi] standard defines an API for Wasm runtimes to provide access to Wasm components to the environment and resources outside the host using a capabilities model.
 
 > [!IMPORTANT]
-> WASI nodepools now use [containerd shims][wasm-containerd-shims] to run WASM workloads. Previously, AKS used [Krustlet][krustlet] to allow WASM modules to be run on Kubernetes. If you are still using Krustlet-based WASI nodepools, you can migrate to containerd shims by creating a new WASI nodepool and migrating your workloads to the new nodepool.
+> WASI nodepools now use [SpinKube shim][containerd-shim-spin] to run Wasm workloads. Previously, AKS used [Krustlet][krustlet] to allow Wasm modules to be run on Kubernetes. If you are still using Krustlet-based WASI nodepools, you can migrate to containerd shims by creating a new WASI nodepool and migrating your workloads to the new nodepool.
 
 ## Before you begin
 
@@ -58,15 +58,15 @@ az provider register --namespace Microsoft.ContainerService
 
 ## Limitations
 
-* Currently, there are only containerd shims available for [spin][spin] and [slight][slight] applications, which use the [wasmtime][wasmtime] runtime. In addition to wasmtime runtime applications, you can also run containers on WASM/WASI node pools.
-* You can run containers and wasm modules on the same node, but you can't run containers and wasm modules on the same pod.
-* The WASM/WASI node pools can't be used for system node pool.
-* The *os-type* for WASM/WASI node pools must be Linux.
-* You can't use the Azure portal to create WASM/WASI node pools.
+* Currently, there are only containerd shims available for [spin][spin] applications, which use the [wasmtime][wasmtime] runtime. In addition to wasmtime runtime applications, you can also run containers on Wasm/WASI node pools.
+* The SpinKube operator is not supported on Wasm/WASI node pools.
+* The Wasm/WASI node pools can't be used for system node pool.
+* The *os-type* for Wasm/WASI node pools must be Linux.
+* You can't use the Azure portal to create Wasm/WASI node pools.
 
-## Add a WASM/WASI node pool to an existing AKS Cluster
+## Add a Wasm/WASI node pool to an existing AKS Cluster
 
-To add a WASM/WASI node pool, use the [az aks nodepool add][az-aks-nodepool-add] command. The following example creates a WASI node pool named *mywasipool* with one node.
+To add a Wasm/WASI node pool, use the [az aks nodepool add][az-aks-nodepool-add] command. The following example creates a WASI node pool named *mywasipool* with one node.
 
 ```azurecli-interactive
 az aks nodepool add \
@@ -122,47 +122,46 @@ Name:               aks-mywasipool-12456878-vmss000000
 Roles:              agent
 Labels:             agentpool=mywasipool
 ...
-                    kubernetes.azure.com/wasmtime-slight-v1=true
-                    kubernetes.azure.com/wasmtime-spin-v1=true
+                    kubernetes.azure.com/wasmtime-spin-v2=true
 ...
 ```
 
-## Running WASM/WASI Workload
+## Running Wasm/WASI Workload
 
-Create a file named *slight.yaml* with the following content:
+Create a file named *spin.yaml* with the following content:
 
 ```yml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wasm-slight
+  name: wasm-spin
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: wasm-slight
+      app: wasm-spin
   template:
     metadata:
       labels:
-        app: wasm-slight
+        app: wasm-spin
     spec:
-      runtimeClassName: wasmtime-slight-v1
+      runtimeClassName: wasmtime-spin-v2
       containers:
-        - name: hello-slight
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:v0.3.3
+        - name: spin-hello
+          image: ghcr.io/spinkube/containerd-shim-spin/examples/spin-rust-hello:v0.15.1
           command: ["/"]
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
             limits:
-              cpu: 500m
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
               memory: 128Mi
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: wasm-slight
+  name: wasm-spin
 spec:
   type: LoadBalancer
   ports:
@@ -170,16 +169,16 @@ spec:
       port: 80
       targetPort: 80
   selector:
-    app: wasm-slight
+    app: wasm-spin
 ```
 
 > [!NOTE]
-> When developing applications, modules should be build against the `wasm32-wasi` target. For more details, see the [spin][spin] and [slight][slight] documentation.
+> When developing applications, modules should be build against the `wasm32-wasi` target. For more details, see the [spin][spin] documentation.
 
 Use `kubectl` to run your example deployment:
 
 ```bash
-kubectl apply -f slight.yaml
+kubectl apply -f spin.yaml
 ```
 
 Use `kubectl get svc` to get the external IP address of the service.
@@ -190,14 +189,14 @@ kubectl get svc
 ```output
 NAME          TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)        AGE
 kubernetes    ClusterIP      10.0.0.1       <none>         443/TCP        10m
-wasm-slight   LoadBalancer   10.0.133.247   <EXTERNAL-IP>  80:30725/TCP   2m47s
+wasm-spin     LoadBalancer   10.0.133.247   <EXTERNAL-IP>  80:30725/TCP   2m47s
 ```
 
 Access the example application at `http://EXTERNAL-IP/hello`. The following example uses `curl`.
 
 ```output
 curl http://EXTERNAL-IP/hello
-hello
+Hello world from Spin!
 ```
 
 > [!NOTE]
@@ -208,45 +207,45 @@ hello
 To remove the example deployment, use `kubectl delete`.
 
 ```bash
-kubectl delete -f slight.yaml
+kubectl delete -f spin.yaml
 ```
 
-To remove the WASM/WASI node pool, use `az aks nodepool delete`.
+To remove the Wasm/WASI node pool, use `az aks nodepool delete`.
 
 ```azurecli-interactive
 az aks nodepool delete --name mywasipool -g myresourcegroup --cluster-name myakscluster
 ```
 
+## Supported runtime classes
+
+The following RuntimeClass are supported on WASI node pools:
+
+- wasmtime-spin-v2 (alias to wasmtime-spin-v0-15-1)
+- wasmtime-spin-v1 (alias to wasmtime-spin-v0-8-0)
+- wasmtime-spin-v0-15-1
+- wasmtime-spin-v0-8-0
+- wasmtime-spin-v0-5-1
+- wasmtime-spin-v0-3-0
+
+The suffix `-v0-15-1`, `-v0-8-0`, `-v0-5-1`, and `-v0-3-0` are the versions of the spin shim. You can find the supported versions of the spin shim in the following table:
+
+
+| **shim version** | v0.15.1                                                                          | v0.8                                                                             | v0.5.1                                                                    | v0.3.0                                                                    |
+| ---------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **[Spin](spin)**         | [v2.6.0](https://github.com/fermyon/spin/releases/tag/v2.6.0)                    | [v1.4.1](https://github.com/fermyon/spin/releases/tag/v1.4.1)                    | [v1.0.0](https://github.com/fermyon/spin/releases/tag/v1.0.0)             | [v0.4.0](https://github.com/fermyon/spin/releases/tag/v0.4.0)             |
 
 <!-- EXTERNAL LINKS -->
-[helm]: https://helm.sh/
 [krustlet]: https://krustlet.dev/
-[krustlet-cni-support]: https://github.com/krustlet/krustlet/issues/533
 [wasm]: https://webassembly.org/
 [wasi]: https://wasi.dev/
-[azure-dns-zone]: https://azure.microsoft.com/services/dns/
-[external-dns]: https://github.com/kubernetes-sigs/external-dns
-[wasm-containerd-shims]: https://github.com/deislabs/containerd-wasm-shims
+[containerd-shim-spin]: https://github.com/spinkube/containerd-shim-spin
 [spin]: https://spin.fermyon.dev/
-[slight]: https://github.com/deislabs/spiderlightning#spiderlightning-or-slight
 [wasmtime]: https://wasmtime.dev/
 <!-- INTERNAL LINKS -->
 
-[az-aks-create]: /cli/azure/aks#az_aks_create
 [az-aks-get-credentials]: /cli/azure/aks#az_aks_get_credentials
 [az-aks-nodepool-add]: /cli/azure/aks/nodepool#az_aks_nodepool_add
-[az-aks-nodepool-list]: /cli/azure/aks/nodepool#az_aks_nodepool_list
-[az-aks-nodepool-update]: /cli/azure/aks/nodepool#az_aks_nodepool_update
-[az-aks-nodepool-upgrade]: /cli/azure/aks/nodepool#az_aks_nodepool_upgrade
-[az-aks-nodepool-scale]: /cli/azure/aks/nodepool#az_aks_nodepool_scale
-[az-aks-nodepool-delete]: /cli/azure/aks/nodepool#az_aks_nodepool_delete
-[az-extension-add]: /cli/azure/extension#az_extension_add
-[az-extension-update]: /cli/azure/extension#az_extension_update
 [az-feature-register]: /cli/azure/feature#az-feature-register
 [az-feature-show]: /cli/azure/feature#az-feature-show
 [az-provider-register]: /cli/azure/provider#az-provider-register
-[dockerhub-callout]: ../container-registry/buffer-gate-public-content.md
-[install-azure-cli]: /cli/azure/install-azure-cli
-[use-multiple-node-pools]: use-multiple-node-pools.md
-[use-system-pool]: use-system-pools.md
 

--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -58,7 +58,7 @@ az provider register --namespace Microsoft.ContainerService
 
 ## Limitations
 
-* Currently, WASI Node Pools only support [Spin][spin] applications, which use the [Wasmtime][wasmtime] runtime and native Linux containers.
+* Currently, WASI node pools only support [Spin][spin] applications, which use the [Wasmtime][wasmtime] runtime and native Linux containers.
 * The SpinKube operator is not supported on Wasm/WASI node pools.
 * The Wasm/WASI node pools can't be used for system node pool.
 * The *os-type* for Wasm/WASI node pools must be Linux.
@@ -232,7 +232,7 @@ The suffix `-v0-15-1`, `-v0-8-0`, `-v0-5-1`, and `-v0-3-0` are the versions of t
 
 | **shim version** | v0.15.1                                                                          | v0.8                                                                             | v0.5.1                                                                    | v0.3.0                                                                    |
 | ---------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **[Spin](spin)**         | [v2.6.0](https://github.com/fermyon/spin/releases/tag/v2.6.0)                    | [v1.4.1](https://github.com/fermyon/spin/releases/tag/v1.4.1)                    | [v1.0.0](https://github.com/fermyon/spin/releases/tag/v1.0.0)             | [v0.4.0](https://github.com/fermyon/spin/releases/tag/v0.4.0)             |
+| **[Spin][spin]**         | [v2.6.0](https://github.com/fermyon/spin/releases/tag/v2.6.0)                    | [v1.4.1](https://github.com/fermyon/spin/releases/tag/v1.4.1)                    | [v1.0.0](https://github.com/fermyon/spin/releases/tag/v1.0.0)             | [v0.4.0](https://github.com/fermyon/spin/releases/tag/v0.4.0)             |
 
 <!-- EXTERNAL LINKS -->
 [krustlet]: https://krustlet.dev/


### PR DESCRIPTION
* replace the slight workload with spin workload
* add a section to describe all the supported runtime classes
* few changes to the wording