### PR TITLE
Fix the feature name - AKSWindowsAnnualPreview

### DIFF
--- a/articles/aks/windows-annual-channel.md
+++ b/articles/aks/windows-annual-channel.md
@@ -65,7 +65,7 @@ The following table compares Windows Annual Channel and Long Term Servicing Chan
 1. Register the `AKSWindowsAnnualPreview` feature flag using the [`az feature register`][az-feature-register] command.
 
     ```azurecli-interactive
-    az feature register --namespace "Microsoft.ContainerService" --name "WindowsAnnualPreview"
+    az feature register --namespace "Microsoft.ContainerService" --name "AKSWindowsAnnualPreview"
     ```
 
     It takes a few minutes for the status to show *Registered*.


### PR DESCRIPTION
The feature name was mentioned as WindowsAnnualPreview instead of AKSWindowsAnnualPreview.
The second command has the right name

<img width="1121" alt="image" src="https://github.com/user-attachments/assets/ebbea942-6632-4fc3-936a-b178b36a5f9a">
