### PR TITLE
Adding missing maxCount factor in load-balancer-standard.md

### DIFF
--- a/articles/aks/load-balancer-standard.md
+++ b/articles/aks/load-balancer-standard.md
@@ -307,7 +307,7 @@ When calculating the number of outbound ports and IPs and setting the values, ke
 * The number of outbound ports per node is fixed based on the value you set.
 * The value for outbound ports must be a multiple of 8.
 * Adding more IPs doesn't add more ports to any node, but it provides capacity for more nodes in the cluster.
-* You must account for nodes that might be added as part of upgrades, including the count of nodes specified via [maxSurge values][maxsurge].
+* You must account for nodes that might be added as part of upgrades, including the count of nodes specified via [maxCount][max-count] and [maxSurge][maxsurge] values.
 
 The following examples show how the values you set affect the number of outbound ports and IP addresses:
 
@@ -677,6 +677,7 @@ To learn more about using internal load balancer for inbound traffic, see the [A
 [use-multiple-node-pools]: use-multiple-node-pools.md
 [troubleshoot-snat]: #troubleshooting-snat
 [service-tags]: /azure/virtual-network/network-security-groups-overview#service-tags
+[max-count]: ./cluster-autoscaler.md#enable-the-cluster-autoscaler-on-an-existing-cluster
 [maxsurge]: ./upgrade-aks-cluster.md#customize-node-surge-upgrade
 [az-lb]: /azure/load-balancer/load-balancer-overview
 [alb-outbound-rules]: /azure/load-balancer/outbound-rules

--- a/articles/aks/load-balancer-standard.md
+++ b/articles/aks/load-balancer-standard.md
@@ -307,7 +307,7 @@ When calculating the number of outbound ports and IPs and setting the values, ke
 * The number of outbound ports per node is fixed based on the value you set.
 * The value for outbound ports must be a multiple of 8.
 * Adding more IPs doesn't add more ports to any node, but it provides capacity for more nodes in the cluster.
-* You must account for nodes that might be added as part of upgrades, including the count of nodes specified via [maxCount][max-count] and [maxSurge][maxsurge] values.
+* You must account for nodes that might be added as part of upgrades, including the count of nodes specified via [maxCount][maxcount] and [maxSurge][maxsurge] values.
 
 The following examples show how the values you set affect the number of outbound ports and IP addresses:
 
@@ -677,7 +677,7 @@ To learn more about using internal load balancer for inbound traffic, see the [A
 [use-multiple-node-pools]: use-multiple-node-pools.md
 [troubleshoot-snat]: #troubleshooting-snat
 [service-tags]: /azure/virtual-network/network-security-groups-overview#service-tags
-[max-count]: ./cluster-autoscaler.md#enable-the-cluster-autoscaler-on-an-existing-cluster
+[maxcount]: ./cluster-autoscaler.md#enable-the-cluster-autoscaler-on-an-existing-cluster
 [maxsurge]: ./upgrade-aks-cluster.md#customize-node-surge-upgrade
 [az-lb]: /azure/load-balancer/load-balancer-overview
 [alb-outbound-rules]: /azure/load-balancer/outbound-rules


### PR DESCRIPTION
**Proposed change:**
Adding `--max-count` as the parameter which will actually reflect the count


**Supporting point:**
1. For the proving the point: configure the nodepool with maxCount = 10, then you can see the following error when set `--load-balancer-outbound-ports` with intentional large number which will definitely make error:
![image](https://github.com/user-attachments/assets/17d885b6-1716-4ae4-8093-2e37b357a52a)
![image](https://github.com/user-attachments/assets/0c538854-c9c6-4979-a094-0ed418f0d34e)
2. I considered if I should name the argument as `max-count` instead of `maxCount`, but since `max-surge` is already being named as `maxSurge`, I will keep the naming convention same. 
