### PR TITLE
Update faq.yml (blocking users from modifying resources)

### DIFF
--- a/articles/aks/faq.yml
+++ b/articles/aks/faq.yml
@@ -100,7 +100,7 @@ sections:
           2. The second resource group, known as the *node resource group*, contains all of the infrastructure resources associated with the cluster. These resources include the Kubernetes node VMs, virtual networking, and storage. By default, the node resource group has a name like *MC_myResourceGroup_myAKSCluster_eastus*. AKS automatically deletes the node resource group whenever you delete the cluster. You should only use this resource group for resources that share the cluster's lifecycle.
 
             > [!NOTE]
-            > Modifying any resource under the node resource group in the AKS cluster is an unsupported action and will cause cluster operation failures. You can prevent changes from being made to the node resource group by [blocking users from modifying resources](./cluster-configuration.md#fully-managed-resource-group-preview) managed by the AKS cluster.
+            > Modifying any resource under the node resource group in the AKS cluster is an unsupported action and will cause cluster operation failures. You can prevent changes from being made to the node resource group by [blocking users from modifying resources](./node-resource-group-lockdown.md) managed by the AKS cluster.
 
       - question: |
           Can I provide my own name for the AKS node resource group?


### PR DESCRIPTION
Should the "_blocking users from modifying resources_" link on line 103 point to https://github.com/MicrosoftDocs/azure-aks-docs/blob/main/articles/aks/node-resource-group-lockdown.md, instead? 