### PR TITLE
docs: remove deprecated yaml key and misspelled value

### DIFF
--- a/articles/aks/advanced-network-observability-cli.md
+++ b/articles/aks/advanced-network-observability-cli.md
@@ -495,7 +495,6 @@ rm hubble-linux-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
             app.kubernetes.io/name: hubble-ui
             app.kubernetes.io/part-of: retina
         spec:
-          serviceAccount: hibble-ui
           serviceAccountName: hubble-ui
           automountServiceAccountToken: true
           containers:


### PR DESCRIPTION
serviceAccount is deprecated field according to the kubernetes API spec: 

```json
"serviceAccount": {
      "type": "string",
      "description": "deprecated; use serviceAccountName instead"
     },
```

 and the value hibble-* misspelled.