### PR TITLE
Update use-node-public-ips.md

### DIFF
--- a/articles/aks/use-node-public-ips.md
+++ b/articles/aks/use-node-public-ips.md
@@ -121,13 +121,13 @@ If a network security group is in place on the subnet with a cluster using bring
 
 ### Host port specification format
 
-When specifying the list of ports to allow, use a comma-separate list with entries in the format of `port/protocol` or `startPort-endPort/protocol`.
+When specifying the list of ports to allow, use a space-separate list with entries in the format of `port/protocol` or `startPort-endPort/protocol`.
 
 Examples:
 
 - 80/tcp
-- 80/tcp,443/tcp
-- 53/udp,80/tcp
+- 80/tcp 443/tcp
+- 53/udp 80/tcp
 - 50000-60000/tcp
 
 ### Requirements


### PR DESCRIPTION
Corrected line 124 , 129 130

--allowed-host-ports must be a space-separated list of port ranges in the format of <port-range>/<protocol>


raghu [ ~ ]$ az aks nodepool update   --resource-group argrg --cluster-name argcl --name nodepool1 --allowed-host-ports 80/tcp,443/tcp,53/udp,40000-60000/tcp,40000-50000/udp   --asg-ids "/
subscriptions/0f587ca2-06f1-4d72-91f0-5f4151909754/resourceGroups/argrg/providers/Microsoft.Network/applicationSecurityGroups/tstarg"
--allowed-host-ports must be a space-separated list of port ranges in the format of <port-range>/<protocol>: '80/tcp,443/tcp,53/udp,40000-60000/tcp,40000-50000/udp'