### PR TITLE
[cost-analysis] Add a note about cost-analysis-identity

### DIFF
--- a/articles/aks/cost-analysis.md
+++ b/articles/aks/cost-analysis.md
@@ -71,6 +71,15 @@ az aks update --resource-group <resource-group> --name <cluster-name> --enable-c
 > [!WARNING]
 > The AKS cost analysis add-on Memory usage is dependent on the number of containers deployed. You can roughly approximate Memory consumption using *200 MB + 0.5 MB per container*. The current Memory limit is set to *4 GB*, which supports approximately *7000 containers per cluster*. These estimates are subject to change.
 
+> [!NOTE]
+> Enabling the cost analysis also creates a [managed identity](/entra/identity/managed-identities-azure-resources/overview) named `cost-analysis-identity` with read access to the cluster's node resource group, and assigns it to the node pools in the cluster.
+> This is used to collect the ARM identifiers of cluster assets for reporting.
+> 
+> Since there is already a managed identity for the node pool itself, any commands on the node that use managed identities will need to [specify the identity to use](/entra/identity/managed-identities-azure-resources/managed-identities-faq#what-identity-will-imds-default-to-if-i-dont-specify-the-identity-in-the-request) rather than relying on the default.
+> 
+> For example, `az login --identity --resource-id <resource ID of identity>`.
+
+
 ## Disable cost analysis on your AKS cluster
 
 Disable cost analysis using the [`az aks update`][az-aks-update] command with the `--disable-cost-analysis` flag.


### PR DESCRIPTION
A customer relying on the default managed identity on the node pool had the commands start failing when they enabled cost analysis.

Add a callout in the documentation indicating that they need to specify identity explicitly once the addon is enabled.

[Discussion](https://teams.microsoft.com/l/message/19:772f22bd22c249f6881c191e5ad8334f@thread.skype/1741417487993?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=e121dbfd-0ec1-40ea-8af5-26075f6a731b&parentMessageId=1741417487993&teamName=Azure%20Container%20Compute&channelName=Observability&createdTime=1741417487993) [IcM](https://portal.microsofticm.com/imp/v5/incidents/details/603923807/summary)