### PR TITLE
Update outdated info in quotas-skus-regions.md

### DIFF
--- a/articles/aks/quotas-skus-regions.md
+++ b/articles/aks/quotas-skus-regions.md
@@ -95,7 +95,7 @@ When you create a cluster using the Azure portal, you can choose a preset config
 |**Azure Monitor**|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|-|-|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|
 |**Secrets store CSI driver**|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|-|-|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|
 |**Network configuration**|Azure CNI Overlay|Azure CNI Overlay|Azure CNI Overlay|Azure CNI Overlay|
-|**Network configuration**|None|None|None|None|
+|**Network policy**|None|None|None|None|
 |**Authentication and Authorization**|Local accounts with Kubernetes RBAC|Local accounts with Kubernetes RBAC|Microsoft Entra ID Authentication with Azure RBAC|Microsoft Entra ID authentication with Azure RBAC|
 
 

--- a/articles/aks/quotas-skus-regions.md
+++ b/articles/aks/quotas-skus-regions.md
@@ -85,18 +85,18 @@ When you create a cluster using the Azure portal, you can choose a preset config
 
 |                              | Production Standard |Dev/Test|Production Economy|Production Enterprise|
 |------------------------------|---------|--------|--------|--------|
-|**System node pool node size**|Standard_D8ds_v5 |Standard_DS2_v2|Standard_D8ds_v5|Standard_D16ds_v5|
-|**System node pool autoscaling range**|2-5 nodes|2-100 nodes|2-5 nodes|2-5 nodes|
+|**System node pool node size**|Standard_D8ds_v5|Standard_D4ds_v5|Standard_D8ds_v5|Standard_D16ds_v5|
+|**System node pool autoscaling range**|2-5 nodes|2-5 nodes|2-5 nodes|2-5 nodes|
 |**User node pool node size**|Standard_D8ds_v5|-|Standard_D8as_v4|Standard_D8ds_v5|
-|**User node pool autoscaling range**|2-100 nodes|-|-|2-100 nodes|
+|**User node pool autoscaling range**|2-100 nodes|-|0-25 nodes|2-100 nodes|
 |**Private cluster**|-|-|-|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|
 |**Availability zones**|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|-|-|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|
 |**Azure Policy**|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|-|-|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|
 |**Azure Monitor**|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|-|-|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|
 |**Secrets store CSI driver**|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|-|-|:::image type="icon" source="./media/quotas-skus-regions/yes-icon.svg":::|
-|**Network configuration**|Azure CNI|Kubenet|Azure CNI|Azure CNI|
-|**Network configuration**|Calico|Calico|Calico|Calico|
-|**Authentication and Authorization**|Local accounts with Kubernetes RBAC|Local accounts with Kubernetes RBAC|Azure AD Authentication with Azure RBAC|Azure AD authentication with Azure RBAC|
+|**Network configuration**|Azure CNI Overlay|Azure CNI Overlay|Azure CNI Overlay|Azure CNI Overlay|
+|**Network configuration**|None|None|None|None|
+|**Authentication and Authorization**|Local accounts with Kubernetes RBAC|Local accounts with Kubernetes RBAC|Microsoft Entra ID Authentication with Azure RBAC|Microsoft Entra ID authentication with Azure RBAC|
 
 
 ## Next steps


### PR DESCRIPTION
**Proposed change:**  
Align the document with latest default setting in portal. 

**Supporting point:**  
One example is: kubenet no longer can be used when creating AKS in Azure portal:  
![image](https://github.com/user-attachments/assets/bafaf12b-34f5-4ca5-8e0e-11af87f992d2)

Related issue: Official announcement - https://github.com/Azure/AKS/issues/4859
This means the outdated document is misleading now which makes users think "kubenet is still supported".

I notice the document is outdated after then. Hence update it. You can check if the info is correct by clicking it in Azure portal.  

Meantime, fixing the typo which is obviously wrong due to duplication:
![image](https://github.com/user-attachments/assets/7e5dbcfc-8da2-46d2-9b09-039f870cc24b)
