### PR TITLE
Update virtual-nodes-cli.md

### DIFF
--- a/articles/aks/virtual-nodes-cli.md
+++ b/articles/aks/virtual-nodes-cli.md
@@ -174,7 +174,7 @@ For more information on managed identities, see [Use managed identities](use-man
             - containerPort: 80
           nodeSelector:
             kubernetes.io/role: agent
-            beta.kubernetes.io/os: linux
+            kubernetes.io/os: linux
             type: virtual-kubelet
           tolerations:
           - key: virtual-kubelet.io/provider


### PR DESCRIPTION
beta.kubernetes.io/os label deprecated.
https://kubernetes.io/docs/reference/labels-annotations-taints/#beta-kubernetes-io-os-deprecated