### PR TITLE
Updated container image for Windows HPC

### DIFF
--- a/articles/aks/use-windows-hpc.md
+++ b/articles/aks/use-windows-hpc.md
@@ -69,7 +69,7 @@ spec:
       hostNetwork: true
       containers:
         - name: powershell
-          image: mcr.microsoft.com/powershell:lts-nanoserver-1809 # or lts-nanoserver-ltsc2022
+          image: mcr.microsoft.com/windows/nanoserver:ltsc2019 # or nanoserver:ltsc2022
           command:
             - powershell.exe
             - -Command


### PR DESCRIPTION
Images powershell:lts-nanoserver-1809/lts-nanoserver-2022 have been deprecated and are no longer valid (https://mcr.microsoft.com/en-us/artifact/mar/powershell/tags), which will lead to deployment failures when attempted.

This PR updates the container image to use a supported nanoserver image for both Windows 2019 and 2022 that also comes bundled with PowerShell.