### PR TITLE
Update aks-extension-kaito.md

### DIFF
--- a/articles/aks/aks-extension-kaito.md
+++ b/articles/aks/aks-extension-kaito.md
@@ -14,7 +14,7 @@ In this article, you learn how to use the AI toolchain operator (KAITO) add-on i
 
 ## Prerequisites
 
-* The Azure Kubernetes Service (AKS) extension for Visual Studio Code has been downloaded. For more information, see [Install the Azure Kubernetes Service (AKS) extension for Visual Studio Code][install-aks-vscode].
+* The Azure Kubernetes Service (AKS) extension for Visual Studio Code needs to be installed to use the KAITO experience. For more information, see [Install the Azure Kubernetes Service (AKS) extension for Visual Studio Code][install-aks-vscode].
 * The cluster that you are deploying to is a Standard Cluster _(Kaito cannot currently be installed on Automatic clusters)_
 * Verify that your Azure subscription has GPU quota for your chosen model by checking the [KAITO model workspaces](https://github.com/kaito-project/kaito/tree/main/presets).
 

--- a/articles/aks/aks-extension-kaito.md
+++ b/articles/aks/aks-extension-kaito.md
@@ -15,7 +15,7 @@ In this article, you learn how to use the AI toolchain operator (KAITO) add-on i
 ## Prerequisites
 
 * The Azure Kubernetes Service (AKS) extension for Visual Studio Code needs to be installed to use the KAITO experience. For more information, see [Install the Azure Kubernetes Service (AKS) extension for Visual Studio Code][install-aks-vscode].
-* The cluster that you are deploying to is a Standard Cluster _(Kaito cannot currently be installed on Automatic clusters)_
+* The cluster that you are deploying to is a Standard Cluster _(Kaito cannot currently be installed on Automatic clusters)_.
 * Verify that your Azure subscription has GPU quota for your chosen model by checking the [KAITO model workspaces](https://github.com/kaito-project/kaito/tree/main/presets).
 
 ## Install KAITO on your cluster

--- a/articles/aks/aks-extension-kaito.md
+++ b/articles/aks/aks-extension-kaito.md
@@ -14,7 +14,8 @@ In this article, you learn how to use the AI toolchain operator (KAITO) add-on i
 
 ## Prerequisites
 
-* The Azure Kubernetes Service (AKS) extension for Visual Studio Code downloaded. For more information, see [Install the Azure Kubernetes Service (AKS) extension for Visual Studio Code][install-aks-vscode].
+* The Azure Kubernetes Service (AKS) extension for Visual Studio Code has been downloaded. For more information, see [Install the Azure Kubernetes Service (AKS) extension for Visual Studio Code][install-aks-vscode].
+* The cluster that you are deploying to is a Standard Cluster _(Kaito cannot currently be installed on Automatic clusters)_
 * Verify that your Azure subscription has GPU quota for your chosen model by checking the [KAITO model workspaces](https://github.com/kaito-project/kaito/tree/main/presets).
 
 ## Install KAITO on your cluster
@@ -69,7 +70,7 @@ For more information, see [AKS extension for Visual Studio Code features][aks-vs
 ## Delete your model inference deployment
 
 1. Once you've finished testing the model(s) and you want to free up the allocated GPU resources on your cluster, go to the Kubernetes tab, and under **Clouds** > **Azure** > **your subscription** > **Deploy a LLM with KAITO**, right click on your cluster and select **Manage KAITO models**.
-2. For each deployed model, select **Delete Workspace** to clear all allocated resources created by the inferencing deployment.
+2. For each deployed model, select **Delete Workspace** to clear all allocated resources created by the inference deployment.
 
 ## Product support and feedback
     


### PR DESCRIPTION
This pull request includes updates to the `articles/aks/aks-extension-kaito.md` file, focusing on improving clarity and correcting terminology. Below are the key changes grouped by theme:

### Documentation Clarity Improvements:
* Updated the prerequisite description for the Azure Kubernetes Service (AKS) extension to clarify that it "has been downloaded" and added a note specifying that KAITO can only be installed on Standard Clusters, not Automatic clusters.

### Terminology Corrections:
* Changed "inferencing deployment" to "inference deployment" in the instructions for deleting model inference deployments to use the correct terminology.