### PR TITLE
Fix AKS - Quick Windows Container Deploy page.

### DIFF
--- a/articles/aks/learn/quick-windows-container-deploy-cli.md
+++ b/articles/aks/learn/quick-windows-container-deploy-cli.md
@@ -171,6 +171,8 @@ az aks nodepool add \
     --node-count 1
 ```
 
+---
+
 ## Connect to the cluster
 
 You use [kubectl][kubectl], the Kubernetes command-line client, to manage your Kubernetes clusters. If you use Azure Cloud Shell, `kubectl` is already installed. If you want to install and run `kubectl` locally, call the [az aks install-cli][az-aks-install-cli] command.


### PR DESCRIPTION
Doc is broken - relevant information on how to connect to the cluster, deploy the application, test and delete is mistakenly placed under one of the tabs.

How it should be (powershell - OK)

![PS](https://github.com/user-attachments/assets/86183718-3d7f-416a-a995-86ebf0022934)

How it is (CLI - NOK):

![CLI](https://github.com/user-attachments/assets/b561b64c-0a67-4289-a624-15acecd6960e)

The content is there - but it is 'hidden' under the last tab:

![HiddenContent](https://github.com/user-attachments/assets/34cc2559-3786-4450-8f3e-c00081aba6e7)

## This PR adds a horizontal line to break away from the tab and make the content visible