### PR TITLE
Added DNS over TCP troubleshooting scenario for Windows GMSA

### DIFF
--- a/articles/aks/use-group-managed-service-accounts.md
+++ b/articles/aks/use-group-managed-service-accounts.md
@@ -401,7 +401,7 @@ If your pod doesn't start after running the `kubectl get pods --watch`  command 
 
 If you see this error message, it may indicate that DNS queries are failing due to blocked TCP fallback.
 
-When gMSA is enabled, the system performs DNS lookups to locate domain controllers (e.g., for _ldap._tcp.dc._msdcs.<domain name>). In large Active Directory environments, these responses can exceed the 512-byte UDP limit. When this happens, the DNS server sets the truncated (TC) flag, prompting CoreDNS to retry the query over TCP, as required by [RFC5966](https://datatracker.ietf.org/doc/html/rfc5966). This fallback to TCP is essential for completing the authentication flow. If TCP traffic on port 53 is blocked by NSG or firewall rules, the DNS resolution, and therefore gMSA login, will fail.
+When gMSA is enabled, the system performs DNS lookups to locate domain controllers (e.g., for `_ldap._tcp.dc._msdcs.<domain>`). In large Active Directory environments, these responses can exceed the 512-byte UDP limit. When this happens, the DNS server sets the truncated (TC) flag, prompting CoreDNS to retry the query over TCP, as required by [RFC5966](https://datatracker.ietf.org/doc/html/rfc5966). This fallback to TCP is essential for completing the authentication flow. If TCP traffic on port 53 is blocked by NSG or firewall rules, the DNS resolution, and therefore gMSA login, will fail.
 
 To verify if this is occurring in your environment, enable [CoreDNS query logging](./coredns-custom.md) and use the `kubectl logs --namespace kube-system -l k8s-app=kube-dns` command to view CoreDNS logs.
 


### PR DESCRIPTION
This pull request adds a new troubleshooting section to the `articles/aks/use-group-managed-service-accounts.md` file, providing guidance on resolving DNS-related issues when using gMSA with Azure Kubernetes Service (AKS).

### Troubleshooting Enhancements:

* Added a new section titled "Container Credential Guard event logs show *'The directory service is not available' errors*" to explain potential DNS query failures caused by blocked TCP fallback.
* Included detailed steps to identify the issue using CoreDNS query logging and `kubectl logs` commands, along with example log patterns for truncated UDP responses and failed TCP retries.
* Recommended updating NSG or firewall rules to allow DNS traffic over TCP on port 53 to resolve the issue and ensure successful gMSA authentication.