### PR TITLE
Update cost-analysis.md to create the resource group before the AKS cluster

### DIFF
--- a/articles/aks/cost-analysis.md
+++ b/articles/aks/cost-analysis.md
@@ -60,6 +60,7 @@ export RANDOM_SUFFIX=$(openssl rand -hex 3)
 export RESOURCE_GROUP="AKSCostRG$RANDOM_SUFFIX"
 export CLUSTER_NAME="AKSCostCluster$RANDOM_SUFFIX"
 export LOCATION="WestUS2"
+az group create --resource-group $RESOURCE_GROUP --location $LOCATION
 az aks create --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME --location $LOCATION --enable-managed-identity --generate-ssh-keys --tier standard --enable-cost-analysis
 ```
 


### PR DESCRIPTION
In the article https://learn.microsoft.com/en-us/azure/aks/cost-analysis the code block that customers copy directly and paste into their console is generating a unique value for RESOURCE_GROUP but it is not creating the resource group, and because of that the code fails.

This can be easily fixed by creating the resource group using the same variable and location variables, before creating the AKS cluster.

![image](https://github.com/user-attachments/assets/fb15d60e-8c9e-4872-8332-3386dbfe3cec)
