### PR TITLE
Update airflow-deploy.md command to reflect apiVersion updates

### DIFF
--- a/articles/aks/airflow-deploy.md
+++ b/articles/aks/airflow-deploy.md
@@ -104,7 +104,7 @@ In this section, we use Helm to install the External Secrets Operator. The Exter
 
     ```bash
     kubectl apply -f - <<EOF
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: SecretStore
     metadata:
       name: azure-store

--- a/articles/aks/airflow-deploy.md
+++ b/articles/aks/airflow-deploy.md
@@ -130,7 +130,7 @@ In this section, we use Helm to install the External Secrets Operator. The Exter
 
     ```bash
     kubectl apply -f - <<EOF
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
       name: airflow-aks-azure-logs-secrets


### PR DESCRIPTION
The `apiVersion: external-secrets.io/v1beta1` for the kind: SecretStore object has been updated meantime to `external-secrets.io/v1`. The documentation must reflect the change because current apiVersion is resulting in object api errors. Confirm by running the commands and check `kubectl api-resources | grep SecretStore`

Article command:
```
kubectl apply -f - <<EOF
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: azure-store
  namespace: ${AKS_AIRFLOW_NAMESPACE}
spec:
  provider:
    # provider type: azure keyvault
    azurekv:
      authType: WorkloadIdentity
      vaultUrl: "${KEYVAULTURL}"
      serviceAccountRef:
        name: ${SERVICE_ACCOUNT_NAME}
EOF
```

Error:
```
error: resource mapping not found for name: "azure-store" namespace: "airflow" from "STDIN": no matches for kind "SecretStore" in version "external-secrets.io/v1beta1"
ensure CRDs are installed first
```

Check:
```
kubectl api-resources | grep SecretStore
secretstores                        ss                  external-secrets.io/v1                    true         SecretStore
```

Updating command to the following apiVersion solves it
```
kubectl apply -f - <<EOF
apiVersion: external-secrets.io/v1
kind: SecretStore
metadata:
  name: azure-store
  namespace: ${AKS_AIRFLOW_NAMESPACE}
spec:
  provider:
    # provider type: azure keyvault
    azurekv:
      authType: WorkloadIdentity
      vaultUrl: "${KEYVAULTURL}"
      serviceAccountRef:
        name: ${SERVICE_ACCOUNT_NAME}
EOF
```