### PR TITLE
Update PostgreSQL deployment instructions and examples for AKS

### DIFF
--- a/articles/aks/deploy-postgresql-ha.md
+++ b/articles/aks/deploy-postgresql-ha.md
@@ -411,7 +411,7 @@ The CNPG operator automatically creates a PodMonitor for the primary instance us
      kind: PodMonitor
      metadata:
       annotations:
-        cnpg.io/operatorVersion: 1.23.1
+        cnpg.io/operatorVersion: 1.27.0
     ...
     ```
 

--- a/articles/aks/postgresql-ha-overview.md
+++ b/articles/aks/postgresql-ha-overview.md
@@ -28,7 +28,6 @@ This article walks through the prerequisites for setting up a PostgreSQL cluster
 * You also need the following resources installed:
 
   * [Azure CLI](/cli/azure/install-azure-cli) version 2.56 or later.
-  * [Azure Kubernetes Service (AKS) preview extension][aks-preview].
   * [jq][jq], version 1.5 or later.
   * [kubectl][install-kubectl] version 1.21.0 or later.
   * [Helm][install-helm] version 3.0.0 or later.
@@ -94,7 +93,6 @@ The type of storage you use can have large effects on PostgreSQL performance. La
 [postgresql]: https://www.postgresql.org/
 [core-kubernetes-concepts]: ./concepts-clusters-workloads.md
 [azure-roles]: /azure/role-based-access-control/built-in-roles
-[aks-preview]: ./draft.md#install-the-aks-preview-azure-cli-extension
 [jq]: https://jqlang.github.io/jq/
 [install-kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [install-helm]: https://helm.sh/docs/intro/install/

--- a/articles/aks/validate-postgresql-ha.md
+++ b/articles/aks/validate-postgresql-ha.md
@@ -63,18 +63,16 @@ In this section, you create a table and insert some data into the app database t
     kubectl cnpg psql $PG_PRIMARY_CLUSTER_NAME --namespace $PG_NAMESPACE
     ```
 
-    ```sql
-    # Run the following PSQL commands to create a small dataset
-    # postgres=#
+  ```sql
+  -- Create a small dataset
+  CREATE TABLE datasample (id INTEGER, name VARCHAR(255));
+  INSERT INTO datasample (id, name) VALUES (1, 'John');
+  INSERT INTO datasample (id, name) VALUES (2, 'Jane');
+  INSERT INTO datasample (id, name) VALUES (3, 'Alice');
+  SELECT COUNT(*) FROM datasample;
+  ```
 
-    CREATE TABLE datasample (id INTEGER,name VARCHAR(255));
-    INSERT INTO datasample (id, name) VALUES (1, 'John');
-    INSERT INTO datasample (id, name) VALUES (2, 'Jane');
-    INSERT INTO datasample (id, name) VALUES (3, 'Alice');
-    SELECT COUNT(*) FROM datasample;
-
-    # Type \q to exit psql
-    ```
+  Type `\q` to exit psql when finished.
 
     Your output should resemble the following example output:
 
@@ -97,35 +95,31 @@ In this section, you create a table and insert some data into the app database t
     kubectl cnpg psql --replica $PG_PRIMARY_CLUSTER_NAME --namespace $PG_NAMESPACE
     ```
 
-    ```sql
-    #postgres=#
-    SELECT pg_is_in_recovery();
-    ```
+  ```sql
+  SELECT pg_is_in_recovery();
+  ```
 
     Example output
 
-    ```output
-    # pg_is_in_recovery
-    #-------------------
-    # t
-    #(1 row)
-    ```
+  ```output
+  pg_is_in_recovery
+  -------------------
+  t
+  (1 row)
+  ```
 
-    ```sql
-    #postgres=#
-    SELECT COUNT(*) FROM datasample;
-    ```
+  ```sql
+  SELECT COUNT(*) FROM datasample;
+  ```
 
     Example output
 
-    ```output
-    # count
-    #-------
-    #     3
-    #(1 row)
-
-    # Type \q to exit psql
-    ```
+  ```output
+  count
+  -------
+    3
+  (1 row)
+  ```
 
 ## Set up on-demand and scheduled PostgreSQL backups using Barman
 


### PR DESCRIPTION
- Simplified extension installation commands in create-postgresql-ha.md
- Updated operator version to 1.27.0 in deploy-postgresql-ha.md
- Removed reference to aks-preview extension in postgresql-ha-overview.md
- Refined SQL commands and output formatting in validate-postgresql-ha.md

## Summary
Updates four PostgreSQL high availability (HA) guidance articles to streamline Azure CLI extension usage, bump CloudNativePG (CNPG) operator version, remove obsolete preview extension reference, and clarify SQL validation steps.

## Changes Included
| File | Purpose of Change | +/- |
|------|-------------------|-----|
| `articles/aks/create-postgresql-ha.md` | Simplify extension installation instructions (drop explicit `aks-preview`), wording cleanup, zone parameter adjustments, and update CNPG manifest URL to 1.27.0 | +14 / -15 |
| `articles/aks/deploy-postgresql-ha.md` | Update `cnpg.io/operatorVersion` annotation to 1.27.0 | +1 / -1 |
| `articles/aks/postgresql-ha-overview.md` | Remove outdated reference to deprecated AKS preview CLI extension | +0 / -2 |
| `articles/aks/validate-postgresql-ha.md` | Refine SQL examples: clearer DDL/DML commands, improved output formatting blocks, remove extraneous prompt characters/comments | +27 / -33 |

Total: 4 files changed, 42 insertions, 51 deletions.

## Rationale
- `aks-preview` extension no longer required for documented flow; reduces setup friction.
- Align CNPG operator version with latest supported (1.27.0) for security fixes and new features.
- Improve readability and copy/paste reliability of SQL validation steps by removing prompt noise and adding fenced code/output blocks.
- Remove stale references to avoid user confusion and maintenance overhead.