### PR TITLE
Add AKS-2025-0011 security bulletin for NPM attacks

### DIFF
--- a/articles/aks/security-bulletins/overview.md
+++ b/articles/aks/security-bulletins/overview.md
@@ -25,6 +25,33 @@ These updates cover security information related to the following AKS components
 
 ---
 
+## AKS-2025-0011  Malicious NPM Packages used in Supply Chain Attacks
+
+**Published Date**: October 1, 2025
+
+### Description
+This bulletin provides an update on Node Package Manager (NPM) packages being compromised. There has been a series of recent NPM supply chain attacks resulting in packages being used to perform malicious activity such as delivering malware or stealing credentials.
+The vulnerability **does not** impact Azure Kubernetes Service (AKS), as Node.js is **not used** in any AKS core or managed components.
+
+### References
+
+- [NPM Security Advisories](https://github.com/advisories?query=npm)
+- [Ongoing Supply Chain Attack Targets CrowdStrike NPM Packages](https://socket.dev/blog/ongoing-supply-chain-attack-targets-crowdstrike-npm-packages#Compromised-Packages-and-Versions)
+
+### Affected Components
+
+#### [**AKS Cluster**](#tab/aks-cluster)
+
+**Affected Versions**
+
+- None
+
+**Resolutions**
+
+- AKS does not use Node.js in any core or managed components and is not affected by these attacks. **No customer action is required.** 
+
+---
+
 ## AKS-2025-0010  Nodes can delete themselves by adding an OwnerReference
 
 **Published Date**: August 15, 2025
@@ -47,7 +74,7 @@ This issue arises because node users are authorized to perform create and patch 
 
 **Resolutions**
 
-- A security patch is currently being rolled out in 20250720 and 20250808 release and is expected to be applied across all regions within the next 4–5 days. You can check the release status from [AKS release tracker][aks-release-tracker].
+- A security patch has been rolled out in 20250720 and 20250808 release. You can check the release status from [AKS release tracker][aks-release-tracker].
 - **No action is required**. The patch will be automatically applied to your cluster during your configured or default [maintenance window](../planned-maintenance.md).
 
 ---


### PR DESCRIPTION
Added security bulletin AKS-2025-0011 regarding malicious NPM packages and clarified that AKS is not affected by these supply chain attacks.