### PR TITLE
Update Pod CIDR recommendation with RFC 6598

### DIFF
--- a/articles/aks/azure-cni-overlay.md
+++ b/articles/aks/azure-cni-overlay.md
@@ -57,7 +57,7 @@ Like Azure CNI Overlay, Kubenet assigns IP addresses to pods from an address spa
 - **Kubernetes DNS service IP address**: This IP address is within the Kubernetes service address range that's used by cluster service discovery. Don't use the first IP address in your address range, as this address is used for the `kubernetes.default.svc.cluster.local` address.
 
 > [!IMPORTANT]
-> The private CIDR ranges available for the Pod CIDR are defined in [RFC 1918](https://tools.ietf.org/html/rfc1918). While we don't block the use of public IP ranges, they are considered out of Microsoft's support scope. We recommend using private IP ranges for pod CIDR. 
+> The private CIDR ranges available for the Pod CIDR are defined in [RFC 1918](https://tools.ietf.org/html/rfc1918) and [RFC 6598](https://tools.ietf.org/html/rfc6598). While we don't block the use of public IP ranges, they are considered out of Microsoft's support scope. We recommend using private IP ranges for pod CIDR. 
 
 > [!IMPORTANT]
 > When using Azure CNI in Overlay mode, ensure that the Pod CIDR does not overlap with any external IP addresses or networks (such as on-premises networks, peered VNets, or ExpressRoute). If an external host uses an IP within the Pod CIDR, packets destined for that host from the Pod may be redirected into the overlay network and SNAT’d by the node, causing the external endpoint to become unreachable.


### PR DESCRIPTION
Added reference to RFC 6598 for Pod CIDR private ranges.

Addresses https://github.com/Azure/AKS/issues/5299