### PR TITLE
fix sample command

### DIFF
--- a/articles/aks/azure-disk-csi.md
+++ b/articles/aks/azure-disk-csi.md
@@ -383,8 +383,7 @@ statefulset.apps/busybox-azuredisk created
 To validate the content of the volume, run the following command:
 
 ```bash
-kubectl exec -it busybox-azuredisk-0 -- cat c:\\mnt\\azuredisk\\data.txt # on Linux/MacOS Bash
-kubectl exec -it busybox-azuredisk-0 -- cat c:\mnt\azuredisk\data.txt # on Windows Powershell/CMD
+ kubectl exec -it statefulset-azuredisk-win-0 -- powershell -c "type c:/mnt/azuredisk/data.txt"
 ```
 
 The output of the command resembles the following example:


### PR DESCRIPTION

The AKS sample statefulset for csi changed to a different name a while ago which meant the sample command in this doc page didn't work anymore. This PR fixes the sample to execute a command in the pod. I also took the opportunity to have a command that works both when run on bash and when run on powershell.

Revised statefulset: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/deploy/example/windows/statefulset.yaml

Snapshot showing the new pod name:

<img width="1301" height="114" alt="image" src="https://github.com/user-attachments/assets/497e58f9-e772-4f34-93eb-74cc2a366097" />
