### PR TITLE
[AKS Network Policy Manager] Windows is no longer onboarding customers

### DIFF
--- a/articles/aks/use-network-policies.md
+++ b/articles/aks/use-network-policies.md
@@ -18,6 +18,8 @@ ms.custom:
 > [!IMPORTANT] 
 > On **30 September 2026**, we’ll end support for Azure Network Policy Manager (NPM) on **Windows** nodes in AKS.
 > 
+> This change applies only to customers who have already onboarded to NPM. **Subscriptions that were not previously registered with this feature will no longer be able to onboard**. Existing onboarded customers can continue using NPM until the end-of-support date.
+>
 >  To ensure your setup continues to receive support, security updates, and deployment compatibility, please explore alternative options, such as using [Network Security Groups (NSGs)](./concepts-network.md) on the node level or open-source tools like [Project Calico](https://www.tigera.io/tigera-products/calico/) by that date. 
 
 > [!IMPORTANT] 
@@ -138,6 +140,8 @@ az aks create \
 
 > [!IMPORTANT] 
 > On **30 September 2026**, we’ll end support for Azure Network Policy Manager (NPM) on Windows nodes in AKS.
+>
+> This change applies only to customers who have already onboarded to NPM. **Subscriptions that were not previously registered with this feature will no longer be able to onboard.** Existing onboarded customers can continue using NPM until the end-of-support date.
 > 
 >  To ensure your setup continues to receive support, security updates, and deployment compatibility, please explore alternative options, such as using [Network Security Groups (NSGs)](./concepts-network.md) on the node level or open-source tools like [Project Calico](https://www.tigera.io/tigera-products/calico/) by that date. 
 


### PR DESCRIPTION
From a recent incident where customers were failing to register the feature flag to use Windows NPM, we received confirmation from engineering that due to the impending deprecation of the feature, no new customers are being onboarded. Supportability will be honored for pre-onboarded customers until the deadline.

This PR changes the deprecation callout to clarify and set expectations.