### PR TITLE
Update upgrade-os-version.md

### DIFF
--- a/articles/aks/upgrade-os-version.md
+++ b/articles/aks/upgrade-os-version.md
@@ -67,7 +67,6 @@ Update the `os-sku` on an existing node pool using the [`az aks nodepool update`
 az aks nodepool update \
     --resource-group $RESOURCE_GROUP \
     --cluster-name $CLUSTER_NAME \
-    --os-type Linux \
     --os-sku Ubuntu \
     --name $NODE_POOL_NAME \
     --node-count 1
@@ -131,7 +130,6 @@ Update to `--os-sku Ubuntu2404` on an existing node pool using the [`az aks node
 az aks nodepool update \
     --resource-group $RESOURCE_GROUP \
     --cluster-name $CLUSTER_NAME \
-    --os-type Linux \
     --os-sku Ubuntu2404 \
     --kubernetes-version 1.32.0 \
     --name $NODE_POOL_NAME \
@@ -157,7 +155,6 @@ Update to `--os-sku AzureLinux3` on an existing node pool using the [`az aks nod
 az aks nodepool update \
     --resource-group $RESOURCE_GROUP \
     --cluster-name $CLUSTER_NAME \
-    --os-type Linux \
     --os-sku AzureLinux3 \
     --kubernetes-version 1.30.0 \
     --name $NODE_POOL_NAME \
@@ -198,7 +195,6 @@ Update to `--os-sku Ubuntu`on an existing node pool using the [`az aks nodepool 
 az aks nodepool update \
     --resource-group $RESOURCE_GROUP \
     --cluster-name $CLUSTER_NAME \
-    --os-type Linux \
     --os-sku Ubuntu \
     --name $NODE_POOL_NAME \
     --node-count 1
@@ -216,7 +212,6 @@ Update to `--os-sku AzureLinux` on an existing node pool using the [`az aks node
 az aks nodepool update \
     --resource-group $RESOURCE_GROUP \
     --cluster-name $CLUSTER_NAME \
-    --os-type Linux \
     --os-sku AzureLinux \
     --name $NODE_POOL_NAME \
     --node-count 1
@@ -237,7 +232,6 @@ Roll back to `--os-sku Ubuntu2204` on an existing node pool using the [`az aks n
 az aks nodepool update \
     --resource-group $RESOURCE_GROUP \
     --cluster-name $CLUSTER_NAME \
-    --os-type Linux \
     --os-sku Ubuntu2204 \
     --kubernetes-version 1.32.0 \
     --name $NODE_POOL_NAME \


### PR DESCRIPTION
--os-type cannot be updated after the node pool is created. 
Removing the --os-type parameter from the az aks nodepool update command.