### PR TITLE
Fixed missing link to az aks mesh get-revisions

### DIFF
--- a/articles/aks/istio-support-policy.md
+++ b/articles/aks/istio-support-policy.md
@@ -99,4 +99,4 @@ The Istio-based service mesh add-on for AKS designates features and [configurati
 [istio-patch-upgrade]: ./istio-upgrade.md#patch-version-upgrade
 [istio-meshconfig]: ./istio-meshconfig.md#allowed-supported-and-blocked-meshconfig-values
 [aks-lts]: ./long-term-support.md
-[az-aks-mesh-get-revisions]: /cli/azure/aks/mesh?view=azure-cli-latest&preserve-view=true#az-aks-mesh-get-revisions
+[az-aks-mesh-get-revisions]: /cli/azure/aks/mesh#az-aks-mesh-get-revisions


### PR DESCRIPTION
Added external link to fix this broken formatting:

<img width="898" height="269" alt="image" src="https://github.com/user-attachments/assets/64476497-ef9a-4294-a009-76e1b49f2104" />
