### PR TITLE
docs: add 90-day node image version validity note to Fleet docs

### DIFF
--- a/articles/kubernetes-fleet/concepts-update-orchestration.md
+++ b/articles/kubernetes-fleet/concepts-update-orchestration.md
@@ -49,6 +49,9 @@ The target node image versions are automatically selected for you based on your 
 
 You should choose `Latest` to use fresher image versions and minimize security risks, and choose `Consistent` to improve reliability by using and verifying those images in clusters in earlier stages before using them in later clusters.
 
+> [!IMPORTANT]
+> Node image versions are only valid for 90 days from their original publish date. If the target node image version selected by an update run exceeds the 90-day window by the time a member cluster is upgraded, the upgrade for that member cluster can fail.
+
 ## Planned maintenance
 
 Update runs honor [planned maintenance windows](/azure/aks/planned-maintenance) that you set at the Azure Kubernetes Service (AKS) cluster level.

--- a/articles/kubernetes-fleet/update-orchestration.md
+++ b/articles/kubernetes-fleet/update-orchestration.md
@@ -126,6 +126,9 @@ Also, `--node-image-selection` flag supports the following values:
 - **Latest**: Updates every AKS cluster in the update run to the latest image available for that cluster in its region.
 - **Consistent**: As it's possible for an update run to have AKS clusters across multiple regions where the latest available node images can be different (check [release tracker](/azure/aks/release-tracker) for more information). The update run picks the **latest common** image across all these regions to achieve consistency.
 
+> [!IMPORTANT]
+> Node image versions are only valid for 90 days from their original publish date. If the target node image version selected by an update run exceeds the 90-day window by the time a member cluster is upgraded, the upgrade for that member cluster can fail.
+
 **Starting an update run**:
 
 To start update runs, run the following command:


### PR DESCRIPTION
Add an important callout in Fleet update orchestration docs noting that node image versions are only valid for 90 days from their publish date. If the target node image version exceeds this window by the time a member cluster is upgraded, the upgrade can fail.

This aligns Fleet documentation with the same restriction already documented in the AKS node pool snapshot feature.