### PR TITLE
Update user-assigned managed identity documentation

### DIFF
--- a/articles/aks/user-assigned-managed-identity.md
+++ b/articles/aks/user-assigned-managed-identity.md
@@ -163,6 +163,7 @@ The output for a successful cluster update to use a user-assigned managed identi
     },
 ...
 ```
+After you update the cluster to use a user-assigned managed identity instead of a service principal, the control plane and pods use the user-assigned managed identity for authorization when accessing other services in Azure. Kubelet continues using a service principal until you also upgrade your agent pool. You can use the az aks nodepool upgrade --resource-group <resource-group-name> --cluster-name <aks-cluster-name> --name <node-pool-name> --node-image-only command on your nodes to update to a user-assigned managed identity. A node pool upgrade causes downtime for your AKS cluster as the nodes in the node pools are cordoned, drained, and reimaged.
 
 > [!NOTE]
 > Migrating a managed identity for the control plane from system-assigned to user-assigned doesn't result in any downtime for control plane and agent pools. Control plane components continue to the old system-assigned identity for up to several hours until the next token refresh.

--- a/articles/aks/user-assigned-managed-identity.md
+++ b/articles/aks/user-assigned-managed-identity.md
@@ -163,7 +163,13 @@ The output for a successful cluster update to use a user-assigned managed identi
     },
 ...
 ```
-After you update the cluster to use a user-assigned managed identity instead of a service principal, the control plane and pods use the user-assigned managed identity for authorization when accessing other services in Azure. Kubelet continues using a service principal until you also upgrade your agent pool. You can use the az aks nodepool upgrade --resource-group <resource-group-name> --cluster-name <aks-cluster-name> --name <node-pool-name> --node-image-only command on your nodes to update to a user-assigned managed identity. A node pool upgrade causes downtime for your AKS cluster as the nodes in the node pools are cordoned, drained, and reimaged.
+After you update the cluster to use a user-assigned managed identity instead of a service principal, the control plane and pods use the user-assigned managed identity for authorization when accessing other services in Azure. Kubelet continues using a service principal until you also upgrade your node pool. A node pool upgrade causes downtime for your AKS cluster as the nodes in the node pools are cordoned, drained, and reimaged. You can use the command on your nodes to update to a user-assigned managed identity.
+```azurecli-interactive
+az aks nodepool upgrade \
+  --resource-group <resource-group-name> \
+  --cluster-name <aks-cluster-name> \
+  --name <node-pool-name> \
+  --node-image-only 
 
 > [!NOTE]
 > Migrating a managed identity for the control plane from system-assigned to user-assigned doesn't result in any downtime for control plane and agent pools. Control plane components continue to the old system-assigned identity for up to several hours until the next token refresh.

--- a/articles/aks/user-assigned-managed-identity.md
+++ b/articles/aks/user-assigned-managed-identity.md
@@ -164,12 +164,14 @@ The output for a successful cluster update to use a user-assigned managed identi
 ...
 ```
 After you update the cluster to use a user-assigned managed identity instead of a service principal, the control plane and pods use the user-assigned managed identity for authorization when accessing other services in Azure. Kubelet continues using a service principal until you also upgrade your node pool. A node pool upgrade causes downtime for your AKS cluster as the nodes in the node pools are cordoned, drained, and reimaged. You can use the command on your nodes to update to a user-assigned managed identity.
+
 ```azurecli-interactive
 az aks nodepool upgrade \
   --resource-group <resource-group-name> \
   --cluster-name <aks-cluster-name> \
   --name <node-pool-name> \
-  --node-image-only 
+  --node-image-only
+```
 
 > [!NOTE]
 > Migrating a managed identity for the control plane from system-assigned to user-assigned doesn't result in any downtime for control plane and agent pools. Control plane components continue to the old system-assigned identity for up to several hours until the next token refresh.


### PR DESCRIPTION
Clarify the process of updating to a user-assigned managed identity and note the impact on Kubelet and node pools. 
system assigned identity document has update node image section after updating the cluster with identity, in user assigned identity there is no point mentioning that node image has to be update. Can you please review the same and update accordingly