### PR TITLE
Add section for enabling gateway access logging with the Telemetry API

### DIFF
--- a/articles/aks/istio-gateway-api.md
+++ b/articles/aks/istio-gateway-api.md
@@ -638,7 +638,7 @@ You can modify these settings for all Istio `Gateways` at a `GatewayClass` level
 
 `Telemetry` CRDs are installed automatically with the Istio add-on. You can use the `Telemetry API` to configure access logging for `Gateway` pods.
 
-Create the resource in the `aks-istio-system` namespace to enable access logs for all gateways in the mesh, or in a specific namespace to enable access logs only for gateways in that namespace.
+Create the resource in the `aks-istio-system` namespace to enable access logs for all `Gateway` pods in the mesh, or in a specific namespace to enable access logs only for `Gateway` pods in that namespace.
 
 The following example shows a `Telemetry` resource that enables `Gateway` access logging:
 

--- a/articles/aks/istio-gateway-api.md
+++ b/articles/aks/istio-gateway-api.md
@@ -652,7 +652,6 @@ spec:
   accessLogging:
   - providers:
     - name: envoy
-
 ```
 
   > [!NOTE]

--- a/articles/aks/istio-gateway-api.md
+++ b/articles/aks/istio-gateway-api.md
@@ -640,7 +640,7 @@ You can modify these settings for all Istio `Gateways` at a `GatewayClass` level
 
 Create the resource in the `aks-istio-system` namespace to enable access logs for all gateways in the mesh, or in a specific namespace to enable access logs only for gateways in that namespace.
 
-The following example shows a `Telemetry` resource that enables gateway access logging:
+The following example shows a `Telemetry` resource that enables `Gateway` access logging:
 
 ```yaml
 apiVersion: telemetry.istio.io/v1

--- a/articles/aks/istio-gateway-api.md
+++ b/articles/aks/istio-gateway-api.md
@@ -634,6 +634,27 @@ You can modify these settings for all Istio `Gateways` at a `GatewayClass` level
     updated-per-gateway
     ```
 
+## Enable access logs for the Gateway pods
+
+With managed Istio enabled on the cluster, the `Telemetry` CRDs are installed automatically. You can use these CRDs to configure access logging for gateway pods by creating a `Telemetry` resource.
+
+Create the resource in the `aks-istio-system` namespace to enable access logs for all gateways in the mesh, or in a specific namespace to enable access logs only for gateways in that namespace.
+
+The following example shows a `Telemetry` resource that enables gateway access logging:
+
+```yaml
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: aks-istio-system
+spec:
+  accessLogging:
+  - providers:
+    - name: envoy
+
+```
+
 ## Clean up resources
 
 If you no longer need the resources created in this article, you can delete them to avoid incurring any charges.

--- a/articles/aks/istio-gateway-api.md
+++ b/articles/aks/istio-gateway-api.md
@@ -636,7 +636,7 @@ You can modify these settings for all Istio `Gateways` at a `GatewayClass` level
 
 ## Enable access logs for the Gateway pods
 
-With managed Istio enabled on the cluster, the `Telemetry` CRDs are installed automatically. You can use these CRDs to configure access logging for gateway pods by creating a `Telemetry` resource.
+`Telemetry` CRDs are installed automatically with the Istio add-on. You can use the `Telemetry API` to configure access logging for `Gateway` pods.
 
 Create the resource in the `aks-istio-system` namespace to enable access logs for all gateways in the mesh, or in a specific namespace to enable access logs only for gateways in that namespace.
 

--- a/articles/aks/istio-gateway-api.md
+++ b/articles/aks/istio-gateway-api.md
@@ -655,6 +655,9 @@ spec:
 
 ```
 
+  > [!NOTE]
+  >  The above manifest enables access logging across the entire mesh including `Istio sidecars` and `Gateway`pods. Use selectors to target specific pods. Refer to the [Istio add-on documentation][istio-telemetry] for more details on how to configure access logging with the `Telemetry API`.
+
 ## Clean up resources
 
 If you no longer need the resources created in this article, you can delete them to avoid incurring any charges.
@@ -686,6 +689,7 @@ If you no longer need the resources created in this article, you can delete them
 
 <!---LINKS--->
 [app-routing-gateway-api]: app-routing-gateway-api.md
+[istio-telemetry]: istio-telemetry.md
 [aks-csi-driver]: ./csi-secrets-store-driver.md
 [azure-internal-lb]: ./internal-lb.md
 [istio-deploy-addon]: istio-deploy-addon.md

--- a/articles/aks/istio-gateway-api.md
+++ b/articles/aks/istio-gateway-api.md
@@ -656,7 +656,7 @@ spec:
 ```
 
   > [!NOTE]
-  >  The above manifest enables access logging across the entire mesh including `Istio sidecars` and `Gateway`pods. Use selectors to target specific pods. Refer to the [Istio add-on documentation][istio-telemetry] for more details on how to configure access logging with the `Telemetry API`.
+  >  The above manifest enables access logging across the entire mesh, both for `Gateway` pods as well as sidecar proxies injected by Istio. Use selectors to target specific pods. Refer to the [Istio add-on documentation][istio-telemetry] for more details on how to configure access logging with the `Telemetry API`.
 
 ## Clean up resources
 


### PR DESCRIPTION
This PR adds a new section to the public documentation that explains how to enable access logging for gateway pods when managed Istio is enabled on an AKS cluster.

### The new content:

- clarifies that Telemetry CRDs are installed automatically with managed Istio
- explains how a Telemetry resource can be used to configure gateway access logging
- documents the namespace scope of the resource:
- aks-istio-system for all gateways in the mesh
- a specific namespace for gateways in that namespace only
- includes an example manifest

### Why

This fills a documentation gap by showing customers how to enable and scope gateway access logs using the supported Telemetry API. this is very useful for troubleshooting and tracing the traffic going through the gateway