### PR TITLE
Update limitations for API Server VNet Integration

### DIFF
--- a/articles/aks/api-server-vnet-integration.md
+++ b/articles/aks/api-server-vnet-integration.md
@@ -26,6 +26,8 @@ API Server VNet Integration is supported for public or private clusters. You can
 
 ## Limitations
 * API Server VNet Integration does not support [Virtual Network Encryption](/azure/virtual-network/virtual-network-encryption-overview). Clusters deployed on **v3 or earlier AKS node SKUs** (which do not support VNet Encryption) are allowed but traffic will not be encrypted. Clusters deployed on **v4 or later AKS node SKUs** (which support VNet Encryption) are blocked because encrypted VNets are incompatible with API Server VNet Integration. See [AKS supported VM SKUs](quotas-skus-regions.md#supported-vm-sizes) for details.
+* Dual-stack networking is not supported 
+* IPv6 is not supported with API Server VNet Integration
 
 ## Availability
 - API Server VNet Integration is available in all GA public cloud regions except qatarcentral.


### PR DESCRIPTION
Added limitations regarding dual-stack networking and IPv6 support for API Server VNet Integration.
If a cluster configured with dual-stack is migrated to API Server VNet Integration it is possible that the IPv6 ip will be assigned. If this occurs then the cluster will become irrecoverably broken, and the only supported resolution is to recreate the cluster.