### PR TITLE
docs: update service CIDR documentation for Kubernetes 1.33 GA extension

### DIFF
--- a/articles/aks/concepts-network-azure-cni-overlay.md
+++ b/articles/aks/concepts-network-azure-cni-overlay.md
@@ -4,7 +4,8 @@ description: Learn about Azure CNI Overlay networking in Azure Kubernetes Servic
 ms.service: azure-kubernetes-service
 ms.subservice: aks-networking
 ms.topic: overview
-ms.date: 05/14/2024
+ms.date: 04/16/2026
+ai-usage: ai-assisted
 author: schaffererin
 ms.author: schaffererin
 ms.custom: fasttrack-edit
@@ -70,6 +71,9 @@ When you plan IP address space for pods, consider the following factors:
 ### Kubernetes service address range
 
 The size of the service address CIDR depends on the number of cluster services that you plan to create. It must be smaller than `/12`. This range shouldn't overlap with the pod CIDR range, cluster subnet range, and IP range used in peered virtual networks and on-premises networks.
+
+> [!NOTE]
+> Starting with Kubernetes 1.33, you can extend the service IP range after cluster creation using the `ServiceCIDR` Kubernetes resource. For more information, see [Extend Service IP Ranges](https://kubernetes.io/docs/tasks/network/extend-service-ip-ranges/) in the Kubernetes documentation.
 
 ### Kubernetes service IP address for DNS
 

--- a/articles/aks/concepts-network-ip-address-planning.md
+++ b/articles/aks/concepts-network-ip-address-planning.md
@@ -2,7 +2,8 @@
 title: Concepts - IP address planning in Azure Kubernetes Service (AKS)
 description: Learn about IP address planning in Azure Kubernetes Service (AKS).
 ms.topic: concept-article
-ms.date: 05/28/2024
+ms.date: 04/16/2026
+ai-usage: ai-assisted
 author: schaffererin
 ms.author: schaffererin
 
@@ -48,7 +49,7 @@ The IP address plan for an AKS cluster consists of a virtual network, at least o
 | -------------- | -------------- | ----------------- |
 | Azure Virtual Network | Max size /8. 65,536 configured IP address limit. See [Azure CNI Pod Subnet Static Block Allocation][pod-subnet-static-block-allocation] for more details | Overlapping address spaces within your network can cause issues. |
 | Subnet | Must be large enough to accommodate nodes, pods, and all Kubernetes and Azure resources in your cluster. For instance, if you deploy an internal Azure Load Balancer, its front-end IPs are allocated from the cluster subnet, not public IPs. | Subnet size should also account for upgrade operations and future scaling needs. <p/> Use the following equation to calculate the minimum subnet size, including an extra node for upgrade operations: `(number of nodes + max surge nodes) + ((number of nodes + max surge nodes) * maximum pods per node that you configure)` <p/> Example for a 50-node cluster: `(51) + (51 * 30 (default)) = 1,581` (/21 or larger) <p/> Example for a 50-node cluster, preparing to scale up an extra 10 nodes with the default max surge of 1 node: `(61) + (61 * 30 (default)) = 1,891` (/21 or larger) <p/> If you don't specify a maximum number of pods per node when you create your cluster, the maximum number of pods per node is set to 30. The minimum number of IP addresses required is based on that value. If you calculate your minimum IP address requirements on a different maximum value, see [Maximum pods per node](#maximum-pods-per-node) to set this value when you deploy your cluster. |
-| Kubernetes Service Address Range | Any network element on or connected to this virtual network must not use this range. | The service address CIDR must be smaller than /12. You can reuse this range across different AKS clusters. |
+| Kubernetes Service Address Range | Any network element on or connected to this virtual network must not use this range. | The service address CIDR must be smaller than /12. You can reuse this range across different AKS clusters. Starting with Kubernetes 1.33, you can [extend the service IP range](https://kubernetes.io/docs/tasks/network/extend-service-ip-ranges/) after cluster creation using the `ServiceCIDR` resource. |
 | Kubernetes DNS Service IP Address | IP address within the Kubernetes service address range used by cluster service discovery. | Don't use the first IP address in your address range. The first address in your subnet range is used for the _kubernetes.default.svc.cluster.local_ address. |
 
 ## Maximum pods per node

--- a/articles/aks/concepts-network-legacy-cni.md
+++ b/articles/aks/concepts-network-legacy-cni.md
@@ -2,7 +2,8 @@
 title: Concepts - AKS Legacy Container Networking Interfaces (CNI)
 description: Learn about legacy CNI networking options in Azure Kubernetes Service (AKS)
 ms.topic: concept-article
-ms.date: 05/29/2024
+ms.date: 04/16/2026
+ai-usage: ai-assisted
 author: schaffererin
 ms.author: schaffererin
 
@@ -47,7 +48,10 @@ When you create an AKS cluster, the following parameters are configurable for Az
 
 **Azure Network Plugin**: When Azure network plugin is used, the internal LoadBalancer service with "externalTrafficPolicy=Local" can't be accessed from VMs with an IP in clusterCIDR that doesn't belong to AKS cluster.
 
-**Kubernetes service address range**: This parameter is the set of virtual IPs that Kubernetes assigns to internal [services][services] in your cluster. This range can't be updated after you create your cluster. You can use any private address range that satisfies the following requirements:
+**Kubernetes service address range**: This parameter is the set of virtual IPs that Kubernetes assigns to internal [services][services] in your cluster. You can use any private address range that satisfies the following requirements:
+
+> [!NOTE]
+> Starting with Kubernetes 1.33, you can extend the service IP range after cluster creation by using the `ServiceCIDR` Kubernetes resource. For more information, see [Extend Service IP Ranges](https://kubernetes.io/docs/tasks/network/extend-service-ip-ranges/) in the Kubernetes documentation. On clusters running earlier versions, the service address range can't be updated after you create the cluster.
 
 - Must not be within the virtual network IP address range of your cluster.
 - Must not overlap with any other virtual networks with which the cluster virtual network peers.

--- a/articles/aks/configure-kubenet.md
+++ b/articles/aks/configure-kubenet.md
@@ -7,7 +7,8 @@ ms.author: davidsmatlak
 ms.subservice: aks-networking
 ms.custom: devx-track-azurecli
 ms.topic: how-to
-ms.date: 05/22/2024
+ms.date: 04/16/2026
+ai-usage: ai-assisted
 # Customer intent: As a cloud architect, I want to configure kubenet networking for my AKS cluster within an existing virtual network, so that I can optimize IP address management and support my application demands efficiently.
 ---
 
@@ -25,7 +26,7 @@ This article shows you how to use kubenet networking to create and use a virtual
 
 * The virtual network for the AKS cluster must allow outbound internet connectivity.
 * Don't create more than one AKS cluster in the same subnet.
-* AKS clusters can't use `169.254.0.0/16`, `172.30.0.0/16`, `172.31.0.0/16`, or `192.0.2.0/24` for the Kubernetes service address range, pod address range, or cluster virtual network address range. The range can't be updated after you create your cluster.
+* AKS clusters can't use `169.254.0.0/16`, `172.30.0.0/16`, `172.31.0.0/16`, or `192.0.2.0/24` for the Kubernetes service address range, pod address range, or cluster virtual network address range. On clusters running Kubernetes versions earlier than 1.33, these ranges can't be updated after you create your cluster. Starting with Kubernetes 1.33, you can extend the service IP range after cluster creation using the [`ServiceCIDR`](https://kubernetes.io/docs/tasks/network/extend-service-ip-ranges/) Kubernetes resource.
 * The cluster identity used by the AKS cluster must at least have the [Network Contributor](/azure/role-based-access-control/built-in-roles#network-contributor) role on the subnet within your virtual network. CLI helps set the role assignment automatically. If you're using an ARM template or other clients, you need to manually set the role assignment. You must also have the appropriate permissions, such as the subscription owner, to create a cluster identity and assign it permissions. If you want to define a [custom role](/azure/role-based-access-control/custom-roles) instead of using the built-in Network Contributor role, you need the following permissions:
   * `Microsoft.Network/virtualNetworks/subnets/join/action`
   * `Microsoft.Network/virtualNetworks/subnets/read`

--- a/articles/aks/use-byo-cni.md
+++ b/articles/aks/use-byo-cni.md
@@ -6,7 +6,8 @@ author: davidsmatlak
 ms.author: davidsmatlak
 ms.subservice: aks-networking
 ms.topic: how-to
-ms.date: 06/20/2023
+ms.date: 04/16/2026
+ai-usage: ai-assisted
 # Customer intent: As an advanced Kubernetes user, I want to deploy an AKS cluster with no preinstalled CNI plugin so that I can use a custom CNI solution that aligns with my on-premises environment.
 ---
 
@@ -52,6 +53,9 @@ All AKS clusters, including those using BYO CNI, require a Kubernetes service ad
 - The DNS service IP must be within the service CIDR range and must not be the first IP address in the range.
 
 These requirements are independent of the CNI plugin.
+
+> [!NOTE]
+> Starting with Kubernetes 1.33, you can extend the service IP range after cluster creation using the `ServiceCIDR` Kubernetes resource. For more information, see [Extend Service IP Ranges](https://kubernetes.io/docs/tasks/network/extend-service-ip-ranges/) in the Kubernetes documentation.
 
 ### Pod networking and IP management
 


### PR DESCRIPTION
Update five networking articles to reflect that service IP ranges can now be extended after cluster creation on Kubernetes 1.33+ clusters using the ServiceCIDR resource (GA since K8s 1.33, MultiCIDRServiceAllocator feature gate enabled by default).

Updated articles:
- concepts-network-legacy-cni.md
- configure-kubenet.md
- concepts-network-ip-address-planning.md
- concepts-network-azure-cni-overlay.md
- use-byo-cni.md