### PR TITLE
Update AKS availability zones configuration details

### DIFF
--- a/articles/aks/reliability-availability-zones-configure.md
+++ b/articles/aks/reliability-availability-zones-configure.md
@@ -40,6 +40,15 @@ Keep the following limitations and considerations in mind when using availabilit
 
 - Review [Quotas, virtual machine size restrictions, and region availability in AKS][aks-vm-sizes].
 - Most Azure regions support availability zones. For more information, see the [List of Azure regions][zones].
+- All VM SKUs are not accepted by AKS when creating node pools in a specified location. This limitation can be for a specific zone and will result in failure. Availablity can be checked using `az aks list-vm-skus`.
+  
+  ```azurecli-interactive
+  az aks list-vm-skus \
+    --location eastus \
+    --size Standard_D8ps_v5 \
+    --all \
+    --output table
+  ```
 - You _can't change_ the number of availability zones after you create a node pool. To change the number of availability zones, you must create a new node pool with the desired number of zones and migrate your workloads to the new node pool.
 
 ## AKS cluster components

--- a/articles/aks/reliability-availability-zones-configure.md
+++ b/articles/aks/reliability-availability-zones-configure.md
@@ -40,7 +40,7 @@ Keep the following limitations and considerations in mind when using availabilit
 
 - Review [Quotas, virtual machine size restrictions, and region availability in AKS][aks-vm-sizes].
 - Most Azure regions support availability zones. For more information, see the [List of Azure regions][zones].
-- All VM SKUs are not accepted by AKS when creating node pools in a specified location. This limitation can be for a specific zone and will result in failure. Availablity can be checked using `az aks list-vm-skus`.
+- Not all VM SKUs are accepted by AKS when you create node pools in a specified location. Node pool creation fails if the selected VM SKU doesn't support the requested availability zones in that region. Check availability by using `az aks list-vm-skus`.
   
   ```azurecli-interactive
   az aks list-vm-skus \


### PR DESCRIPTION
Added information about VM SKU limitations and how to check availability in AKS.

There are cases when the VM is available in the region/zones and customer have quota, but AKS won't accept it.

For example, The Azure Compute API (az vm list-skus) will confirm the VM SKU is available in centralus with zone support [1,2,3] and no restrictions. However, the AKS node pool API reports zones=empty for this SKU, causing the nodepool creation to fail:

Error: AvailabilityZoneNotSupported - The zone(s) 2 for resource nodepool1 is not supported. The supported zones for location centralus are (empty).