### PR TITLE
Add advisory for CVE-2026-31431 vulnerability

### DIFF
--- a/articles/aks/security-bulletins/overview.md
+++ b/articles/aks/security-bulletins/overview.md
@@ -24,7 +24,7 @@ These updates cover security information related to the following AKS components
 - Azure Kubernetes Service Addons (AKS add-ons)
 
 ---
-## AKS-2026-0003 # AKS Advisory & Mitigation Guide for CVE-2026-31431 (Copy Fail) 
+## AKS-2026-0003 AKS Advisory & Mitigation Guide for CVE-2026-31431 (Copy Fail)
 
 **Published Date**: May 1, 2026
 
@@ -75,7 +75,8 @@ This mitigation is being applied to:
 
 Monitor the hotfix rollout status in [AKS Advisory](https://github.com/Azure/AKS/issues/5753)
 
-> **⚠️ Important**: Existing nodes created **before** the hotfix VHD is available are **NOT protected** and remain exploitable. We strongly recommend applying the self-service mitigation decsribed in [AKS Advisory](https://github.com/Azure/AKS/issues/5753)
+> ![IMPORTANT]
+> Existing nodes created **before** the hotfix VHD is available are **NOT protected** and remain exploitable. We strongly recommend applying the self-service mitigation described in [AKS Advisory](https://github.com/Azure/AKS/issues/5753).
 
 ---
 

--- a/articles/aks/security-bulletins/overview.md
+++ b/articles/aks/security-bulletins/overview.md
@@ -24,8 +24,63 @@ These updates cover security information related to the following AKS components
 - Azure Kubernetes Service Addons (AKS add-ons)
 
 ---
+## AKS-2026-0003 # AKS Advisory & Mitigation Guide for CVE-2026-31431 (Copy Fail) 
 
-## AKS-2026-0002 gRPC-Go Authorization Bypass via Missing Leading Slash in :path - CVE-2026-33186
+**Published Date**: May 1, 2026
+
+### Description
+
+This bulletin provides an update on a local privilege escalation (LPE) vulnerability that was publicly disclosed on April 29, 2026 affecting the Linux kernel's `algif_aead` module. This vulnerability has been assigned **CVE-2026-31431** and is referred to as **"Copy Fail"**.
+
+- **CVSS Score**: 7.8 HIGH (`CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`)
+- **Attack Vector**: Local — requires code execution on the node (e.g., from a container)
+- **Affected Component**: `algif_aead` kernel module (hardware-accelerated cryptographic functions)
+- **Canonical Advisory**: https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available
+
+### References
+
+- [CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431)
+- [AKS Advisory](https://github.com/Azure/AKS/issues/5753)
+
+### Affected Components
+
+#### [**AKS Node Image**](#tab/aks-node-image)
+
+**Affected Versions**
+
+- All current AKS Linux nodes are exploitable
+  
+- Although `algif_aead` is **not loaded by default** on AKS nodes, the Linux kernel's module auto-loading mechanism (`request_module`) will **automatically load it on demand** when any process — **including unprivileged containers** — creates an AF_ALG socket with AEAD type. This means:
+
+- **An attacker with code execution in any pod (even non-root) can escalate to root on the node**
+- No special pod privileges, capabilities, or host access are required
+- The exploit has been [confirmed working on AKS nodes](#issuecomment-4359550164) from a non-root pod (UID 1000)
+
+| OS | Kernel | Module auto-loads? | Exploitable? |
+|----|--------|--------------------|-------------|
+| Ubuntu 20.04 FIPS | 5.4.0-1160-azure-fips | ✅ Yes | ⚠️ **Yes** |
+| Ubuntu 22.04 | 5.15.0-1102-azure | ✅ Yes | ⚠️ **Yes** |
+| Ubuntu 24.04 | 6.8.0-1052-azure | ✅ Yes | ⚠️ **Yes** |
+| AzureLinux 3.0 | 6.6.130.1-3.azl3 | ✅ Yes | ⚠️ **Yes** |
+
+- **AzureLinux 2.0 (Mariner)** and **Windows** nodes are **not affected**.
+
+**Resolutions**
+
+The AKS team is deploying a mitigation that **blocks the module from auto-loading** via `modprobe` configuration (`install algif_aead /bin/false`). This prevents the kernel from loading the vulnerable module even when triggered by an application.
+
+This mitigation is being applied to:
+- ✅ **New VHDs** (baked into VHD image builds for `v20260413` and `v20260424`)
+- ✅ **New nodes** created from patched VHDs will be protected automatically
+
+Monitor the hotfix rollout status in [AKS Advisory](https://github.com/Azure/AKS/issues/5753)
+
+> **⚠️ Important**: Existing nodes created **before** the hotfix VHD is available are **NOT protected** and remain exploitable. We strongly recommend applying the self-service mitigation decsribed in [AKS Advisory](https://github.com/Azure/AKS/issues/5753)
+
+---
+
+
+## AKS-2026-0002 gRPC-Go Authorization Bypass via Missing Leading Slash in :path 
 
 **Published Date**: March 20, 2026
 

--- a/articles/aks/security-bulletins/overview.md
+++ b/articles/aks/security-bulletins/overview.md
@@ -54,7 +54,7 @@ This bulletin provides an update on a local privilege escalation (LPE) vulnerabi
 
 - **An attacker with code execution in any pod (even non-root) can escalate to root on the node**
 - No special pod privileges, capabilities, or host access are required
-- The exploit has been [confirmed working on AKS nodes](#issuecomment-4359550164) from a non-root pod (UID 1000)
+- The exploit has been [confirmed working on AKS nodes](https://github.com/Azure/AKS/issues/5753#issuecomment-435955016) from a non-root pod (UID 1000)
 
 | OS | Kernel | Module auto-loads? | Exploitable? |
 |----|--------|--------------------|-------------|


### PR DESCRIPTION
Added advisory for CVE-2026-31431 detailing a local privilege escalation vulnerability in the Linux kernel's algif_aead module, including affected components and mitigations.