### PR TITLE
Fix: typo in aks-list-skus.md - GOUP to GROUP

### DIFF
--- a/articles/aks/aks-list-skus.md
+++ b/articles/aks/aks-list-skus.md
@@ -53,7 +53,7 @@ In this article, you learn how to:
 Set the following environment variables to use with commands in this article:
 
 ```azurecli-interactive
-export RESOURCE_GOUP=<resource-group-name>
+export RESOURCE_GROUP=<resource-group-name>
 export CLUSTER_NAME=<cluster-name>
 export LOCATION=<location>
 ```


### PR DESCRIPTION
Fix variable name typo: changed GOUP to GROUP in aks-list-skus.md