### PR TITLE
Fix: zones not displayed in table output for az aks list-vm-skus

### DIFF
--- a/articles/aks/aks-list-skus.md
+++ b/articles/aks/aks-list-skus.md
@@ -53,7 +53,7 @@ In this article, you learn how to:
 Set the following environment variables to use with commands in this article:
 
 ```azurecli-interactive
-export RESOURCE_GOUP=<resource-group-name>
+export RESOURCE_GROUP=<resource-group-name>
 export CLUSTER_NAME=<cluster-name>
 export LOCATION=<location>
 ```
@@ -114,7 +114,7 @@ List supported VM SKUs on an AKS cluster using the [`az aks list-vm-skus`][az-ak
 az aks list-vm-skus \
 	--location $LOCATION \
 	--zone \
-	--query "[].{name:name,zones:locationInfo[0].zones}" \
+	--query "[].{name:name,zones:join(', ', locationInfo[0].zones)}" \
 	--output table
 ```
 


### PR DESCRIPTION
Use JMESPath join() function to convert zones array to a comma-separated string for proper display in table output format.