### PR TITLE
docs: add resource lock restriction to node resource group FAQ

### DIFF
--- a/articles/aks/faq.yml
+++ b/articles/aks/faq.yml
@@ -136,6 +136,7 @@ sections:
           - Change the node resource group name after you create the cluster.
           - Specify names for the managed resources within the node resource group.
           - Modify or delete Azure-created tags of managed resources within the node resource group.
+          - Apply [Azure resource locks](/azure/azure-resource-manager/management/lock-resources) to the node resource group or to resources within it.
 
       - question: |
           Can I modify tags and other properties of the AKS resources in the node resource group?


### PR DESCRIPTION
Hi.

A.T., the resource locks will cause AKS operation failures, but is not documented. This has been the behavior for years to protect unpexpected locks causing operation failures in-flight. This PR explicitly document not to place locks in FAQ.