### PR TITLE
doc(AKS): clarify OSM add-on retirement path to Istio add-on

### DIFF
--- a/articles/aks/TOC.yml
+++ b/articles/aks/TOC.yml
@@ -152,7 +152,7 @@
       items:
         - name: Service meshes overview
           href: servicemesh-about.md
-        - name: Istio service mesh AKS add-on
+        - name: Istio add-on
           items:
             - name: Deployment and configuration
               items:
@@ -204,11 +204,11 @@
                   href: istio-telemetry.md
                 - name: Collect metrics in Azure Managed Prometheus
                   href: istio-metrics-managed-prometheus.md
-        - name: Open Service Mesh AKS add-on
+        - name: Open Service Mesh (OSM) add-on
           items:
-            - name: About Open Service Mesh
+            - name: About the OSM add-on
               href: open-service-mesh-about.md
-            - name: Migration Guidance to Istio AKS add-on
+            - name: Migration guidance from the OSM add-on to the Istio add-on
               href: open-service-mesh-istio-migration-guidance.md
             - name: Use the Azure CLI
               href: open-service-mesh-deploy-addon-az-cli.md
@@ -216,11 +216,11 @@
               href: open-service-mesh-deploy-addon-bicep.md
             - name: Install the OSM CLI
               href: open-service-mesh-binary.md
-            - name: Open Service Mesh integrations
+            - name: OSM add-on integrations
               href: open-service-mesh-integrations.md
-            - name: Troubleshoot Open Service Mesh
+            - name: Troubleshoot the OSM add-on
               href: open-service-mesh-troubleshoot.md
-            - name: Uninstall the Open Service Mesh AKS add-on
+            - name: Uninstall the OSM add-on
               href: open-service-mesh-uninstall-add-on.md
 - name: Create and manage node pools
   items:

--- a/articles/aks/includes/open-service-mesh-retirement.md
+++ b/articles/aks/includes/open-service-mesh-retirement.md
@@ -1,10 +1,12 @@
 ---
 ms.service: azure-kubernetes-service
 ms.topic: include
-ms.date: 01/14/2026
+ms.date: 05/27/2026
 author: schaffererin
 ms.author: schaffererin
 ---
 
 > [!IMPORTANT]
-> Starting on **September 30, 2027**, Azure Kubernetes Service (AKS) no longer supports the Open Service Mesh (OSM) add-on. The [Cloud Native Computing Foundation (CNCF)](https://docs.openservicemesh.io/) retired the upstream OSM project. [Migrate any existing OSM configurations to equivalent Istio configurations](/azure/aks/open-service-mesh-istio-migration-guidance). For more information on this retirement, see the [Azure Updates retirement announcement](https://azure.microsoft.com/updates?id=open-service-mesh-add-on-for-aks-will-be-retired-on-september-30-2027). To stay informed on announcements and updates, follow the [AKS release notes](https://github.com/Azure/AKS/releases).
+> Starting on **September 30, 2027**, Azure Kubernetes Service (AKS) no longer supports the Open Service Mesh (OSM) add-on. The upstream [Open Service Mesh project](https://docs.openservicemesh.io/) has been retired.
+>
+> If your cluster uses the OSM add-on, migrate to the Istio add-on before the end-of-support date. In this notice, OSM add-on and Istio add-on refer to the managed AKS add-ons. The notice does not apply to upstream Open Service Mesh deployments or self-managed Istio installations. Use the [migration guidance from the OSM add-on to the Istio add-on](/azure/aks/open-service-mesh-istio-migration-guidance) as a reference. To stay informed about AKS announcements and updates, follow the [AKS release notes](https://github.com/Azure/AKS/releases).

--- a/articles/aks/open-service-mesh-about.md
+++ b/articles/aks/open-service-mesh-about.md
@@ -2,7 +2,7 @@
 title: Open Service Mesh in Azure Kubernetes Service (AKS)
 description: Learn about the Open Service Mesh (OSM) add-on in Azure Kubernetes Service (AKS).
 ms.topic: concept-article
-ms.date: 09/25/2024
+ms.date: 05/27/2026
 ms.author: schaffererin
 author: schaffererin
 # Customer intent: As a Kubernetes administrator, I want to enable the Open Service Mesh add-on in my AKS cluster, so that I can enhance service communication security and observability within my microservices architecture.
@@ -23,15 +23,7 @@ Microsoft started the OSM project, but it's now governed by the [Cloud Native Co
 OSM can be added to your Azure Kubernetes Service (AKS) cluster by enabling the OSM add-on using the [Azure CLI][osm-azure-cli] or a [Bicep template][osm-bicep]. The OSM add-on provides a fully supported installation of OSM that's integrated with AKS.
 
 > [!IMPORTANT]
-> Based on the version of Kubernetes your cluster is running, the OSM add-on installs a different version of OSM.
->
-> |Kubernetes version         | OSM version installed |
-> |---------------------------|-----------------------|
-> | 1.24.0 or greater         | 1.2.5                 |
-> | Between 1.23.5 and 1.24.0 | 1.1.3                 |
-> | Below 1.23.5              | 1.0.0                 |
->
-> Older versions of OSM may not be available for install or be actively supported if the corresponding AKS version has reached end of life. You can check the [AKS Kubernetes release calendar](./supported-kubernetes-versions.md#aks-kubernetes-release-calendar) for information on AKS version support windows.
+> The Kubernetes version of your cluster determines which OSM add-on component version is installed on your AKS cluster. To see which OSM add-on version maps to each AKS version, see the **AKS managed add-ons** column of the [Kubernetes component version table](./supported-kubernetes-versions.md#aks-components-breaking-changes-by-version). To verify the version installed on your cluster, inspect the `osm-controller` image after installation.
 
 ## Capabilities and features
 
@@ -53,7 +45,7 @@ For more information on ingress and OSM, see [Using ingress to manage external a
 
 ## Limitations
 
-The OSM AKS add-on has the following limitations:
+The OSM add-on has the following limitations:
 
 - After installation, you must enable Iptables redirection for port IP address and port range exclusion using `kubectl patch`. For more information, see [iptables redirection][ip-tables-redirection].
 - Any pods that need access to IMDS, Azure DNS, or the Kubernetes API server must have their IP addresses added to the global list of excluded outbound IP ranges using [Global outbound IP range exclusions][global-exclusion].

--- a/articles/aks/open-service-mesh-binary.md
+++ b/articles/aks/open-service-mesh-binary.md
@@ -3,7 +3,7 @@ title: Download the OSM client Library
 description: Download and configure the Open Service Mesh (OSM) client library
 ms.topic: concept-article
 ms.custom: linux-related-content
-ms.date: 09/25/2024
+ms.date: 05/27/2026
 ms.author: schaffererin
 author: schaffererin
 zone_pivot_groups: client-operating-system
@@ -17,15 +17,7 @@ This article shows how to download the OSM client library to operate and configu
 [!INCLUDE [open-service-mesh-retirement](./includes/open-service-mesh-retirement.md)]
 
 > [!IMPORTANT]
-> Based on the version of Kubernetes your cluster is running, the OSM add-on installs a different version of OSM.
->
-> |Kubernetes version         | OSM version installed |
-> |---------------------------|-----------------------|
-> | 1.24.0 or greater         | 1.2.5                 |
-> | Between 1.23.5 and 1.24.0 | 1.1.3                 |
-> | Below 1.23.5              | 1.0.0                 |
->
-> Older versions of OSM may not be available for install or be actively supported if the corresponding AKS version has reached end of life. You can check the [AKS Kubernetes release calendar](./supported-kubernetes-versions.md#aks-kubernetes-release-calendar) for information on AKS version support windows.
+> The Kubernetes version of your cluster determines which OSM add-on component version is installed on your AKS cluster. To see which OSM add-on version maps to each AKS version, see the **AKS managed add-ons** column of the [Kubernetes component version table](./supported-kubernetes-versions.md#aks-components-breaking-changes-by-version). To verify the version installed on your cluster, inspect the `osm-controller` image after installation.
 
 ::: zone pivot="client-operating-system-linux"
 

--- a/articles/aks/open-service-mesh-deploy-addon-az-cli.md
+++ b/articles/aks/open-service-mesh-deploy-addon-az-cli.md
@@ -3,7 +3,7 @@ title: Install the Open Service Mesh (OSM) add-on using Azure CLI
 description: Use Azure CLI to install the Open Service Mesh (OSM) add-on on an Azure Kubernetes Service (AKS) cluster.
 ms.topic: how-to
 ms.custom: devx-track-azurecli
-ms.date: 09/25/2024
+ms.date: 05/27/2026
 ms.author: schaffererin
 author: schaffererin
 # Customer intent: As a Kubernetes administrator, I want to install the Open Service Mesh add-on using Azure CLI, so that I can manage traffic, enforce policies, and collect telemetry for my applications running on an Azure Kubernetes Service cluster.
@@ -16,15 +16,7 @@ This article shows you how to install the Open Service Mesh (OSM) add-on on an A
 [!INCLUDE [open-service-mesh-retirement](./includes/open-service-mesh-retirement.md)]
 
 > [!IMPORTANT]
-> Based on the version of Kubernetes your cluster is running, the OSM add-on installs a different version of OSM.
->
-> |Kubernetes version         | OSM version installed |
-> |---------------------------|-----------------------|
-> | 1.24.0 or greater         | 1.2.5                 |
-> | Between 1.23.5 and 1.24.0 | 1.1.3                 |
-> | Below 1.23.5              | 1.0.0                 |
->
-> Older versions of OSM may not be available for install or be actively supported if the corresponding AKS version has reached end of life. You can check the [AKS Kubernetes release calendar](./supported-kubernetes-versions.md#aks-kubernetes-release-calendar) for information on AKS version support windows.
+> The Kubernetes version of your cluster determines which OSM add-on component version is installed on your AKS cluster. To see which OSM add-on version maps to each AKS version, see the **AKS managed add-ons** column of the [Kubernetes component version table](./supported-kubernetes-versions.md#aks-components-breaking-changes-by-version). To verify the version installed on your cluster, inspect the `osm-controller` image after installation.
 
 ## Prerequisites
 

--- a/articles/aks/open-service-mesh-deploy-addon-bicep.md
+++ b/articles/aks/open-service-mesh-deploy-addon-bicep.md
@@ -3,7 +3,7 @@ title: Deploy the Open Service Mesh add-on using Bicep in Azure Kubernetes Servi
 description: Use a Bicep template to deploy the Open Service Mesh (OSM) add-on to Azure Kubernetes Service (AKS).
 ms.topic: how-to
 ms.custom: devx-track-bicep
-ms.date: 09/25/2024
+ms.date: 05/27/2026
 ms.author: schaffererin
 author: schaffererin
 # Customer intent: As a cloud developer, I want to deploy the Open Service Mesh add-on to an Azure Kubernetes Service cluster using a Bicep template, so that I can efficiently manage microservices communication and ensure proper service mesh configurations.
@@ -16,15 +16,7 @@ This article shows you how to deploy the Open Service Mesh (OSM) add-on to Azure
 [!INCLUDE [open-service-mesh-retirement](./includes/open-service-mesh-retirement.md)]
 
 > [!IMPORTANT]
-> Based on the version of Kubernetes your cluster is running, the OSM add-on installs a different version of OSM.
->
-> |Kubernetes version         | OSM version installed |
-> |---------------------------|-----------------------|
-> | 1.24.0 or greater         | 1.2.5                 |
-> | Between 1.23.5 and 1.24.0 | 1.1.3                 |
-> | Below 1.23.5              | 1.0.0                 |
->
-> Older versions of OSM may not be available for install or be actively supported if the corresponding AKS version has reached end of life. You can check the [AKS Kubernetes release calendar](./supported-kubernetes-versions.md#aks-kubernetes-release-calendar) for information on AKS version support windows.
+> The Kubernetes version of your cluster determines which OSM add-on component version is installed on your AKS cluster. To see which OSM add-on version maps to each AKS version, see the **AKS managed add-ons** column of the [Kubernetes component version table](./supported-kubernetes-versions.md#aks-components-breaking-changes-by-version). To verify the version installed on your cluster, inspect the `osm-controller` image after installation.
 
 [Bicep](/azure/azure-resource-manager/bicep/overview) is a domain-specific language that uses declarative syntax to deploy Azure resources. You can use Bicep in place of creating [Azure Resource Manager templates](/azure/azure-resource-manager/templates/overview) to deploy your infrastructure-as-code Azure resources.
 

--- a/articles/aks/open-service-mesh-istio-migration-guidance.md
+++ b/articles/aks/open-service-mesh-istio-migration-guidance.md
@@ -1,20 +1,20 @@
 ---
-title: Migration guidance for Open Service Mesh to Istio
-description: Migration guidance for Open Service Mesh configurations to Istio
-services: container-service
+title: Migration guidance from the Open Service Mesh (OSM) add-on to the Istio add-on
+description: Learn how to migrate from the Open Service Mesh (OSM) add-on to the Istio add-on for Azure Kubernetes Service (AKS).
+ms.service: azure-kubernetes-service
 ms.topic: how-to
-ms.date: 09/25/2024
+ms.date: 05/27/2026
 ms.author: schaffererin
 author: schaffererin
-# Customer intent: "As a cloud engineer migrating microservices from Open Service Mesh to Istio, I want detailed guidance on translating OSM configurations to Istio equivalents, so that I can ensure a seamless transition and effective management of my workloads within the Istio service mesh."
+# Customer intent: "As a cloud engineer migrating microservices from the OSM add-on to the Istio add-on, I want guidance for translating OSM add-on configurations to Istio add-on equivalents, so that I can plan the changes needed for my workloads."
 ---
 
-# Migration guidance for Open Service Mesh (OSM) configurations to Istio
+# Migration guidance from the Open Service Mesh (OSM) add-on to the Istio add-on
 
 > [!IMPORTANT]
-> This article aims to provide a simplistic understanding of how to identify OSM configurations and translate them to equivalent Istio configurations for migrating workloads from OSM to Istio. This by no means, is considered to be an exhaustive detailed guide.
+> This article introduces how to identify OSM add-on configurations and translate them to equivalent Istio add-on configurations. It is not an exhaustive production migration runbook.
 
-This article provides practical guidance for mapping OSM policies to the [Istio](https://istio.io/) policies to help migrate your microservices deployments managed by OSM over to being managed by Istio. We utilize the OSM [Bookstore sample application](https://docs.openservicemesh.io/docs/getting_started/install_apps/) as a base reference for current OSM users. The following walk-through deploys the Bookstore application. The same steps are followed and explain how to apply the OSM [SMI](https://smi-spec.io/) traffic policies using the Istio equivalent.
+This article provides practical guidance for mapping OSM add-on policies to the equivalent Istio add-on policies. The source and target in this article are both managed Azure Kubernetes Service add-ons. This article does not cover migration from upstream Open Service Mesh to a self-managed or open source Istio installation. We utilize the OSM [Bookstore sample application](https://docs.openservicemesh.io/docs/getting_started/install_apps/) as a base reference for current OSM add-on users. The following walk-through deploys the Bookstore application. The same steps are followed and explain how to apply the OSM [SMI](https://smi-spec.io/) traffic policies using the Istio add-on equivalent.
 
 If you are not using OSM and are new to Istio, start with [Istio's own Getting Started guide](https://istio.io/latest/docs/setup/getting-started/) to learn how to use the Istio service mesh for your applications. If you are currently using OSM, make sure you are familiar with the OSM [Bookstore sample application](https://docs.openservicemesh.io/docs/getting_started/install_apps/) walk-through on how OSM configures traffic policies. The following walk-through does not duplicate the current documentation, and reference specific topics when relevant. You should be comfortable and fully aware of the bookstore application architecture before proceeding.
 
@@ -22,9 +22,9 @@ If you are not using OSM and are new to Istio, start with [Istio's own Getting S
 
 - An Azure subscription. If you don't have an Azure subscription, you can create a [free account](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn).
 - [Azure CLI installed](/cli/azure/install-azure-cli).
-- The OSM AKS add-on is uninstalled from your AKS cluster
+- The OSM add-on is uninstalled from your AKS cluster
 - Any existing OSM Bookstore application, including namespaces, is uninstalled and deleted from your cluster
-- [Install the Istio AKS service mesh add-on](istio-deploy-addon.md)
+- [Install the Istio add-on](istio-deploy-addon.md)
 
 ## Modifications needed to the OSM Sample Bookstore Application
 


### PR DESCRIPTION
### Summary

This PR updates AKS service mesh documentation to clarify the OSM add-on retirement path to the Istio add-on.

It updates the OSM retirement notice so the call to action is to move from the OSM add-on to the Istio add-on before September 30, 2027. The notice now scopes that guidance to managed AKS add-ons and avoids implying that it applies to upstream Open Service Mesh deployments or self-managed Istio installations.

The stale duplicated OSM version table was removed from the OSM overview, CLI, Bicep, and binary articles. Those articles now point readers to the supported Kubernetes versions component table, where AKS managed add-on versions are already maintained.

### Changes

- Updated the service mesh table of contents entries to use `Istio add-on`, `Open Service Mesh (OSM) add-on`, and `OSM add-on` consistently.
- Renamed the OSM to Istio migration article title and description so the page is framed as OSM add-on to Istio add-on guidance.
- Updated the retirement include to describe the OSM add-on retirement path, remove the stale Azure Updates link, and point to the OSM add-on to Istio add-on migration guidance.
- Replaced stale OSM version tables with pointers to the AKS managed add-ons column in the Kubernetes component version table.
- Updated `ms.date` metadata on the OSM pages touched by the version table replacement.