### PR TITLE
Update query for public IP ID in nat-gateway.md

### DIFF
--- a/articles/aks/nat-gateway.md
+++ b/articles/aks/nat-gateway.md
@@ -101,7 +101,7 @@ The following table describes each outbound IP parameter and when to use it:
         --allocation-method Static \
         --version IPv4 \
         --zone 1 2 3 \
-        --query id \
+        --query publicIp.id \
         --output tsv)
     
     export MY_IP_PREFIX_ID=$(az network public-ip prefix create \


### PR DESCRIPTION
The query should be publicIp.id as the command output in json as the following:
$az network public-ip create --resource-group $MY_RG --name $MY_IP --location eastus2 --sku StandardV2 --allocation-method Static --version IPv4 --zone 1 2 3 

{
  "publicIp": {
    "ddosSettings": {
      "protectionMode": "VirtualNetworkInherited"
    },
    "etag": "W/\"xxxx\"",
    "id": "/subscriptions/xxxx/resourceGroups/nat/providers/Microsoft.Network/publicIPAddresses/myNatOutboundIP",
    "idleTimeoutInMinutes": 4,
    "ipAddress": "x.x.x.x",
    "ipTags": [
      {
        "ipTagType": "FirstPartyUsage",
        "tag": "/Unprivileged"
      }
    ],
    "location": "eastus2",
    "name": "myNatOutboundIP",
    "provisioningState": "Succeeded",
    "publicIPAddressVersion": "IPv4",
    "publicIPAllocationMethod": "Static",
    "resourceGroup": "nat",
    "resourceGuid": "xxxx",
    "sku": {
      "name": "StandardV2",
      "tier": "Regional"
    },
    "type": "Microsoft.Network/publicIPAddresses",
    "zones": [
      "1",
      "2",
      "3"
    ]
  }
}