### PR TITLE
Add warning about aks-preview extension incompatibility with AKS Automatic BYO VNet

### DIFF
--- a/articles/aks/automatic/quick-automatic-custom-network.md
+++ b/articles/aks/automatic/quick-automatic-custom-network.md
@@ -41,6 +41,9 @@ If you don't have an Azure account, create a [free account](https://azure.micros
 - AKS Automatic will [enable Azure Policy on your AKS cluster][policy-for-kubernetes], but you should pre-register the `Microsoft.PolicyInsights` resource provider in your subscription for a smoother experience. For more information, see [Azure resource providers and types][az-provider-register] for more information.
 - Uninstall the AKS-preview extension using `az extension remove -n aks-preview`. 
 
+> [!IMPORTANT]
+> The `aks-preview` CLI extension is incompatible with AKS Automatic custom virtual network deployments. If the extension is installed, it overrides the `az aks create` command surface and hides the required `--node-subnet-id` and `--system-node-subnet-id` parameters. Using the legacy `--vnet-subnet-id` parameter instead will cause the deployment to be accepted but fail after a prolonged timeout (up to 2 hours) during node provisioning. Always remove the `aks-preview` extension before creating AKS Automatic clusters with custom virtual networks.
+
 [!INCLUDE [Kubernetes gateway](../includes/aks-automatic/aks-automatic-kubernetes-gateway.md)]
 
 [!INCLUDE [Automatic limitations](../includes/aks-automatic/aks-automatic-limitations.md)]

--- a/articles/aks/automatic/quick-automatic-private-custom-network.md
+++ b/articles/aks/automatic/quick-automatic-private-custom-network.md
@@ -42,6 +42,9 @@ In this quickstart, you learn to:
 - AKS Automatic will [enable Azure Policy on your AKS cluster][policy-for-kubernetes], but you should preregister the `Microsoft.PolicyInsights` resource provider in your subscription for a smoother experience. For more information, see [Azure resource providers and types][az-provider-register].
 - Uninstall the AKS-preview extension using `az extension remove -n aks-preview`. 
 
+> [!IMPORTANT]
+> The `aks-preview` CLI extension is incompatible with AKS Automatic custom virtual network deployments. If the extension is installed, it overrides the `az aks create` command surface and hides the required `--node-subnet-id` and `--system-node-subnet-id` parameters. Using the legacy `--vnet-subnet-id` parameter instead will cause the deployment to be accepted but fail after a prolonged timeout (up to 2 hours) during node provisioning. Always remove the `aks-preview` extension before creating AKS Automatic clusters with custom virtual networks.
+
 
 [!INCLUDE [Kubernetes gateway](../includes/aks-automatic/aks-automatic-kubernetes-gateway.md)]
 


### PR DESCRIPTION
## Summary

Adds an IMPORTANT callout box to both AKS Automatic custom VNet quickstart docs (private and public) explaining that the `aks-preview` CLI extension is incompatible with these deployments.

## Context

Since hosted system pool GA on June 2, 2026, the `aks-preview` extension overrides the `az aks create` command surface and hides the required `--node-subnet-id` and `--system-node-subnet-id` parameters. Customers who have the extension installed and fall back to the legacy `--vnet-subnet-id` parameter will have their deployment accepted by the RP but it will fail after up to 2 hours during node provisioning (NIC creation against a non-existent VNet).

The existing prerequisite bullet says to uninstall the extension but does not explain the consequences of ignoring it. This PR adds a prominent warning callout that explains:
- What happens if you leave it installed
- Why the deployment fails silently (accepted but times out)
- That you must always remove it before creating AKS Automatic clusters with custom VNets

## Related

- ICM 51000001094157
- Affects: `articles/aks/automatic/quick-automatic-private-custom-network.md`
- Affects: `articles/aks/automatic/quick-automatic-custom-network.md`