### PR TITLE
Clarify Premium SSD v2 IOPS and throughput guidance

### DIFF
--- a/articles/aks/use-premium-v2-disks.md
+++ b/articles/aks/use-premium-v2-disks.md
@@ -178,7 +178,8 @@ Events:
 
 ## Set IOPS and throughput limits
 
-Input/Output Operations Per Second (IOPS) and throughput limits for Azure Premium SSD v2 are currently not supported through AKS. To adjust performance, you can use the Azure CLI command [az disk update][az-disk-update] and including the `--disk-iops-read-write` and `--disk-mbps-read-write` parameters.
+After an Azure Premium SSD v2 disk has been provisioned for use with AKS, post-provisioning changes to IOPS and throughput aren't configured through AKS node pool settings or the AKS management plane. 
+Instead, these changes can be made either through the CSI driver (such as disk.csi.azure.com ) by using the CSI volume modification flow (for example, ModifyVolume / VolumeAttributesClass), or directly on the managed disk by using the Azure CLI command [az disk update][az-disk-update] and including the `--disk-iops-read-write` and `--disk-mbps-read-write` parameters.
 
 The following example updates the disk IOPS read/write to **5000** and Mbps to **200**. For `--resource-group`, the value must be the second resource group automatically created to store the AKS worker nodes with the naming convention *MC_resourcegroupname_clustername_location*. For more information, see [Why are two resource groups created with AKS?][aks-two-resource-groups].
 

--- a/articles/aks/use-premium-v2-disks.md
+++ b/articles/aks/use-premium-v2-disks.md
@@ -178,8 +178,8 @@ Events:
 
 ## Set IOPS and throughput limits
 
-After an Azure Premium SSD v2 disk has been provisioned for use with AKS, post-provisioning changes to IOPS and throughput aren't configured through AKS node pool settings or the AKS management plane. 
-Instead, these changes can be made either through the CSI driver (such as disk.csi.azure.com ) by using the CSI volume modification flow (for example, ModifyVolume / VolumeAttributesClass), or directly on the managed disk by using the Azure CLI command [az disk update][az-disk-update] and including the `--disk-iops-read-write` and `--disk-mbps-read-write` parameters.
+After an Azure Premium SSD v2 disk has been provisioned for use with AKS, post-provisioning changes to IOPS and throughput aren't configured through AKS node pool settings or the AKS management plane.
+Instead, make these changes either through the Kubernetes CSI driver (for example, `disk.csi.azure.com`) by using the CSI volume modification flow (for example, `ModifyVolume` with `VolumeAttributesClass`), or directly on the managed disk by using the Azure CLI command [az disk update][az-disk-update] and including the `--disk-iops-read-write` and `--disk-mbps-read-write` parameters.
 
 The following example updates the disk IOPS read/write to **5000** and Mbps to **200**. For `--resource-group`, the value must be the second resource group automatically created to store the AKS worker nodes with the naming convention *MC_resourcegroupname_clustername_location*. For more information, see [Why are two resource groups created with AKS?][aks-two-resource-groups].
 


### PR DESCRIPTION
## Summary
- update the AKS documentation for Azure Premium SSD v2 disks
- clarify the confusing statement about Input/Output Operations Per Second (IOPS) and throughput support through AKS
- explain the supported post-provisioning update paths through the CSI driver flow or Azure CLI
