### PR TITLE
Clarify address range restrictions for AKS clusters CNI networking

### DIFF
--- a/articles/aks/concepts-network-cni-overview.md
+++ b/articles/aks/concepts-network-cni-overview.md
@@ -100,7 +100,7 @@ Although capabilities like service endpoints or UDRs are supported, the [support
 When you're planning your network configuration for AKS, keep these requirements and considerations in mind:
 
 - The virtual network for the AKS cluster must allow outbound internet connectivity.
-- AKS clusters can't use `169.254.0.0/16` or `192.0.2.0/24` for address ranges for the Kubernetes service, pods, or cluster virtual networks. Additionally, AKS clusters with Calico CNI can't use `172.30.0.0/16` or `172.31.0.0/16` address ranges.
+- AKS clusters can't use `169.254.0.0/16` or `192.0.2.0/24` or `172.30.0.0/16` or `172.31.0.0/16`for address ranges for the Kubernetes service, pods, or cluster virtual networks.
 - In scenarios where you bring your own virtual network, the cluster identity that the AKS cluster uses must have at least [Network Contributor](/azure/role-based-access-control/built-in-roles#network-contributor) permissions on the subnet within your virtual network. If you want to define a [custom role](/azure/role-based-access-control/custom-roles) instead of using the built-in Network Contributor role, the following permissions are required:
   - `Microsoft.Network/virtualNetworks/subnets/join/action`
   - `Microsoft.Authorization/roleAssignments/write`


### PR DESCRIPTION
For line 103, it statement: "AKS clusters can't use 169.254.0.0/16 or 192.0.2.0/24 for address ranges for the Kubernetes service, pods, or cluster virtual networks. Additionally, AKS clusters with Calico CNI can't use 172.30.0.0/16 or 172.31.0.0/16 address ranges.". But we tested to create AKS with azure CNI and specified the service cidr 172.30.0.0/16 not calico one, it also failed. Seems that All type  AKS  is can't use 169.254.0.0/16 or 192.0.2.0/24 172.30.0.0/16 or 172.31.0.0/16 for address ranges for the Kubernetes service, pods, or cluster virtual networks.