### PR TITLE
update ai-toolchian-operator docs

### DIFF
--- a/articles/aks/ai-toolchain-operator-azure-portal.md
+++ b/articles/aks/ai-toolchain-operator-azure-portal.md
@@ -26,13 +26,15 @@ Built on top of the open-source KAITO project, the AI toolchain operator managed
 ## Before you begin
 
 - This article assumes a basic understanding of Kubernetes concepts. For more information, see [Kubernetes core concepts for AKS](./concepts-clusters-workloads.md).
-- For **_all hosted model preset images_** and default resource configuration, see the [KAITO GitHub repository](https://github.com/kaito-project/kaito/tree/main/presets).
-- The AI toolchain operator add-on currently supports KAITO **version 0.6.0**. Please make a note of this in considering your choice of model from the KAITO model repository.
+- For ***the curated supported model list*** and default resource configuration, see the [KAITO GitHub document](https://kaito-project.github.io/kaito/docs/presets).
+-The AI toolchain operator add-on typically lags one release behind the latest upstream KAITO version. Please take this into consideration when choosing a model from the KAITO model repository.
+
 
 ## Limitations
 
 - `AzureLinux` and `Windows` OS SKU aren't currently supported.
 - AMD GPU virtual machine (VM) sizes aren't a supported `instanceType` in a KAITO workspace.
+- Virtual machine (VM) sizes using Nvidia GPUs older than the Ampere architecture (such as the T4, V100, M60, and K80) are not supported.
 - AI toolchain operator add-on is supported in **public** Azure regions.
 
 ## Prerequisites

--- a/articles/aks/ai-toolchain-operator.md
+++ b/articles/aks/ai-toolchain-operator.md
@@ -27,13 +27,14 @@ Built on top of the open-source KAITO project, the AI toolchain operator managed
 ## Before you begin
 
 * This article assumes a basic understanding of Kubernetes concepts. For more information, see [Kubernetes core concepts for AKS](./concepts-clusters-workloads.md).
-* For ***all hosted model preset images*** and default resource configuration, see the [KAITO GitHub repository](https://github.com/kaito-project/kaito/tree/main/presets).
-* The AI toolchain operator add-on currently supports KAITO **version 0.6.0**, please make a note of this in considering your choice of model from the KAITO model repository.
+* For ***the curated supported model list*** and default resource configuration, see the [KAITO GitHub document](https://kaito-project.github.io/kaito/docs/presets).
+* The AI toolchain operator add-on typically lags one release behind the latest upstream KAITO version. Please take this into consideration when choosing a model from the KAITO model repository.
 
 ## Limitations
 
 * `Windows` OS SKU is not currently supported.
 * AMD GPU VM sizes are not supported `instanceType` in a KAITO workspace.
+* Virtual machine (VM) sizes using Nvidia GPUs older than the Ampere architecture (such as the T4, V100, M60, and K80) are not supported.
 * AI toolchain operator add-on is supported in **public** Azure regions.
 
 ## Prerequisites


### PR DESCRIPTION
This PR updates the product document to make clarifications about 
1) the link to the latest supported model list.
2) the addon release is usually one release lag behind the upstream release (so that we don't have to update this doc every time we have a new addon release).
3) some old nvidia GPU skus are not supported. 