### PR TITLE
Document kubelogin prerequisite and Azure RBAC propagation for Fleet hub access

### DIFF
--- a/articles/kubernetes-fleet/access-fleet-hub-cluster-kubernetes-api.md
+++ b/articles/kubernetes-fleet/access-fleet-hub-cluster-kubernetes-api.md
@@ -2,10 +2,11 @@
 title: "Access the Kubernetes API for an Azure Kubernetes Fleet Manager Hub Cluster"
 description: Learn how to access the Kubernetes API for an Azure Kubernetes Fleet Manager hub cluster.
 ms.topic: how-to
-ms.date: 04/01/2024
+ms.date: 07/22/2026
 author: schaffererin
 ms.author: schaffererin
 ms.service: azure-kubernetes-fleet-manager
+ai-usage: ai-assisted
 zone_pivot_groups: public-hub-private-hub
 # Customer intent: As a Kubernetes administrator, I want to access the Kubernetes API for my Azure Kubernetes Fleet Manager hub cluster, so that I can manage resource propagation and monitor member clusters.
 ---
@@ -24,6 +25,7 @@ If your Azure Kubernetes Fleet Manager (Kubernetes Fleet) resource was created w
 * [!INCLUDE [free trial note](~/reusable-content/ce-skilling/azure/includes/quickstarts-free-trial-note.md)]
 * You need a Kubernetes Fleet resource with a hub cluster and member clusters. If you don't have one, see [Create an Azure Kubernetes Fleet Manager resource and join member clusters by using the Azure CLI](quickstart-create-fleet-and-members.md).
 * The identity (user or service principal) that you're using needs to have Microsoft.ContainerService/fleets/listCredentials/action permissions on the Kubernetes Fleet resource.
+* You have `kubelogin` installed. The hub cluster kubeconfig uses Microsoft Entra authentication, so `kubectl` relies on `kubelogin` to sign in. For more information, see [Use kubelogin to authenticate users in Azure Kubernetes Service (AKS)](../aks/kubelogin-authentication.md).
 
 :::zone-end
 
@@ -47,6 +49,7 @@ Using Azure Bastion protects your private hub cluster from exposing endpoints to
   * Microsoft.ContainerService/fleets/listCredentials/action permissions on the Kubernetes Fleet resource.
   * Microsoft.Network/bastionHosts/read	on the Bastion Resource.
   * Microsoft.Network/virtualNetworks/read on the virtual network of the private hub cluster.
+* You have `kubelogin` installed. The hub cluster kubeconfig uses Microsoft Entra authentication, so `kubectl` relies on `kubelogin` to sign in. For more information, see [Use kubelogin to authenticate users in Azure Kubernetes Service (AKS)](../aks/kubelogin-authentication.md).
 
 :::zone-end
 
@@ -78,6 +81,9 @@ Using Azure Bastion protects your private hub cluster from exposing endpoints to
     Merged "hub" as current context in /home/fleet/.kube/config
     ```
 
+   > [!NOTE]
+   > The kubeconfig that `az fleet get-credentials` generates uses Microsoft Entra authentication and defaults to device code sign-in. If your tenant enforces a Conditional Access policy that blocks the device code flow, `kubectl` commands fail to authenticate. To convert the kubeconfig to use Azure CLI authentication instead, run `kubelogin convert-kubeconfig -l azurecli`. For more information, see [Can't connect to Azure Kubernetes Fleet Manager hub cluster](/troubleshoot/azure/kubernetes-fleet/unable-connect-azure-fleet-manager).
+
 4. Set the following environment variable for the `FLEET_ID` value of the hub cluster's Kubernetes Fleet resource:
 
     ```azurecli-interactive
@@ -92,6 +98,8 @@ Using Azure Bastion protects your private hub cluster from exposing endpoints to
     * Azure Kubernetes Fleet Manager RBAC Writer
     * Azure Kubernetes Fleet Manager RBAC Admin
     * Azure Kubernetes Fleet Manager RBAC Cluster Admin
+
+   Choose the least-privileged role for your task. The Azure Kubernetes Fleet Manager RBAC Reader role is sufficient for read-only access, such as listing member clusters. The Azure Kubernetes Fleet Manager RBAC Cluster Admin role is required only for cluster-scoped write operations, such as creating namespaces or cluster-scoped resource placements. The following example uses Cluster Admin.
 
     ```azurecli-interactive
     export IDENTITY=$(az ad signed-in-user show --query "id" --output tsv)
@@ -117,6 +125,10 @@ Using Azure Bastion protects your private hub cluster from exposing endpoints to
       "type": "Microsoft.Authorization/roleAssignments"
     }
     ```
+
+   > [!NOTE]
+   > Azure role assignments can take up to 10 minutes to take effect because Azure Resource Manager caches role assignment data. Until the change propagates, `kubectl` commands might return transient `Unauthorized` (HTTP 401) or `Forbidden` (HTTP 403) errors. If access is still denied after you assign the role, wait and retry, or sign out and sign back in to refresh your access token. For more information, see [Troubleshoot Azure RBAC](/azure/role-based-access-control/troubleshooting#symptom---role-assignment-changes-are-not-being-detected).
+
 :::zone target="docs" pivot="public-hub"
 6. Verify that you can access the API server by using the `kubectl get memberclusters` command:
 
@@ -163,6 +175,7 @@ Using Azure Bastion protects your private hub cluster from exposing endpoints to
 
 * [Propagate cluster-scoped resources from a Fleet Manager hub cluster to member clusters](./quickstart-resource-propagation.md)
 * [Propagate namespace-scoped resources from a Fleet Manager hub cluster to member clusters](./quickstart-namespace-scoped-resource-propagation.md)
+* [Can't connect to Azure Kubernetes Fleet Manager hub cluster](/troubleshoot/azure/kubernetes-fleet/unable-connect-azure-fleet-manager)
 
 <!-- LINKS --->
 [az-fleet-get-credentials]: /cli/azure/fleet#az-fleet-get-credentials

--- a/articles/kubernetes-fleet/access-fleet-hub-cluster-kubernetes-api.md
+++ b/articles/kubernetes-fleet/access-fleet-hub-cluster-kubernetes-api.md
@@ -99,7 +99,7 @@ Using Azure Bastion protects your private hub cluster from exposing endpoints to
     * Azure Kubernetes Fleet Manager RBAC Admin
     * Azure Kubernetes Fleet Manager RBAC Cluster Admin
 
-   Choose the least-privileged role for your task. The Azure Kubernetes Fleet Manager RBAC Reader role is sufficient for read-only access, such as listing member clusters. The Azure Kubernetes Fleet Manager RBAC Cluster Admin role is required only for cluster-scoped write operations, such as creating namespaces or cluster-scoped resource placements. The following example uses Cluster Admin.
+   Choose the least-privileged role that covers the resources you need. The Azure Kubernetes Fleet Manager RBAC Reader, RBAC Writer, and RBAC Admin roles grant read-only, read/write, and administrative access to *namespaced* Kubernetes resources on the hub cluster. The Azure Kubernetes Fleet Manager RBAC Cluster Admin role also grants access to *cluster-scoped* resources and custom resources, such as `MemberCluster` and `ClusterResourcePlacement`. This article uses Cluster Admin because the verification step lists the cluster-scoped `memberclusters` resource; creating namespaces or cluster-scoped resource placements likewise requires cluster-scoped access. For a description of each role, see [Grant access to Azure Kubernetes Fleet Manager resources with Azure role-based access control](concepts-rbac.md).
 
     ```azurecli-interactive
     export IDENTITY=$(az ad signed-in-user show --query "id" --output tsv)
@@ -127,7 +127,7 @@ Using Azure Bastion protects your private hub cluster from exposing endpoints to
     ```
 
    > [!NOTE]
-   > Azure role assignments can take up to 10 minutes to take effect because Azure Resource Manager caches role assignment data. Until the change propagates, `kubectl` commands might return transient `Unauthorized` (HTTP 401) or `Forbidden` (HTTP 403) errors. If access is still denied after you assign the role, wait and retry, or sign out and sign back in to refresh your access token. For more information, see [Troubleshoot Azure RBAC](/azure/role-based-access-control/troubleshooting#symptom---role-assignment-changes-are-not-being-detected).
+   > Azure role assignments can take up to 10 minutes to take effect because Azure Resource Manager caches role assignment data. Until the change propagates, `kubectl` commands might return transient `Unauthorized` (HTTP 401) or `Forbidden` (HTTP 403) errors. A `Forbidden` response is returned by Kubernetes authorization; if it persists after the assignment propagates, confirm that your assigned role covers the resource you're accessing. If access is still denied after you assign the role, wait and retry, or sign out and sign back in to refresh your access token. For more information about role assignment propagation delays, see [Troubleshoot Azure RBAC](/azure/role-based-access-control/troubleshooting#symptom---role-assignment-changes-are-not-being-detected).
 
 :::zone target="docs" pivot="public-hub"
 6. Verify that you can access the API server by using the `kubectl get memberclusters` command:


### PR DESCRIPTION
## Summary

The [Access the Kubernetes API for a Fleet Manager hub cluster](https://learn.microsoft.com/en-us/azure/kubernetes-fleet/access-fleet-hub-cluster-kubernetes-api) how-to goes from `az fleet get-credentials` and an Azure role assignment straight to `kubectl`, without covering two supported behaviors that customers hit in practice. This PR adds that guidance to `articles/kubernetes-fleet/access-fleet-hub-cluster-kubernetes-api.md`.

## Changes

- **kubelogin prerequisite + Conditional Access conversion.** Adds `kubelogin` to *Before you begin* (both hub pivots) and a note that the Entra-authenticated kubeconfig defaults to device code sign-in. When a Conditional Access policy blocks the device code flow, `kubectl` fails; the supported remediation is `kubelogin convert-kubeconfig -l azurecli`, per [Can't connect to Azure Kubernetes Fleet Manager hub cluster](https://learn.microsoft.com/en-us/troubleshoot/azure/kubernetes-fleet/unable-connect-azure-fleet-manager).
- **Azure RBAC propagation note.** After the role assignment, documents that role assignments can take up to 10 minutes to take effect (Azure Resource Manager caches role data), that transient `Unauthorized` (401) / `Forbidden` (403) responses are expected until then, and that signing out and back in refreshes the access token. Clarifies that a `Forbidden` response is a Kubernetes authorization decision, and scopes the [Troubleshoot Azure RBAC](https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshooting#symptom---role-assignment-changes-are-not-being-detected) citation to role assignment propagation delays.
- **Role selection clarity.** Describes the Fleet RBAC Reader, Writer, and Admin roles as granting access to *namespaced* Kubernetes resources on the hub cluster, and the RBAC Cluster Admin role as additionally covering *cluster-scoped* resources and custom resources such as `MemberCluster` and `ClusterResourcePlacement`. Explains that the article uses Cluster Admin because its verification step lists the cluster-scoped `memberclusters` resource, and adds an inline cross-link to the Fleet RBAC concepts page. Existing role list and Cluster Admin example are preserved.
- **Cross-link.** Adds the Fleet connectivity troubleshooting article to *Related content*.
- Adds `ai-usage: ai-assisted` and refreshes `ms.date` per repo authoring guidance.

## References

- Rendered page: <https://learn.microsoft.com/en-us/azure/kubernetes-fleet/access-fleet-hub-cluster-kubernetes-api>
- Fleet RBAC concepts: <https://learn.microsoft.com/en-us/azure/kubernetes-fleet/concepts-rbac>
- Troubleshooting source: <https://learn.microsoft.com/en-us/troubleshoot/azure/kubernetes-fleet/unable-connect-azure-fleet-manager>

This gap was identified while validating the customer authentication flow against the public how-to. All statements are grounded in the linked public documentation; no product-specific timing or undocumented behavior is asserted.
