### PR TITLE
Update non-Cilium container network metrics tables (Retina)

### DIFF
--- a/articles/aks/container-network-observability-metrics.md
+++ b/articles/aks/container-network-observability-metrics.md
@@ -125,23 +125,35 @@ For Cilium data plane clusters, node-level metrics are available on Linux only. 
 
 For non-Cilium data plane scenarios, container network metrics are available for both Linux and Windows.
 
-> [!NOTE]
-> Due to a known bug, TCP resets temporarily aren't visible. The **networkobservability_tcp_flag_counters** metric isn't published on Linux at this time.
-
-| Metric name                                    | Description | Extra labels | Linux | Windows |
-|------------------------------------------------|-------------|--------------|-------|---------|
-| **networkobservability_forward_count**         | Total forwarded packet count | `direction` | ✅ | ✅ |
-| **networkobservability_forward_bytes**         | Total forwarded byte count | `direction` | ✅ | ✅ |
-| **networkobservability_drop_count**            | Total dropped packet count | `direction`, `reason` | ✅ | ✅ |
-| **networkobservability_drop_bytes**            | Total dropped byte count | `direction`, `reason` | ✅ | ✅ |
-| **networkobservability_tcp_state**             | TCP active socket count by state | `state` | ✅ | ✅ |
-| **networkobservability_tcp_connection_remote** | TCP active socket count by remote IP/port | `address` (IP), `port` | ✅ | ❌ |
-| **networkobservability_tcp_connection_stats**  | TCP connection statistics (for example, Delayed ACKs, TCPKeepAlive, TCPSackFailures) | `statistic` | ✅ | ✅ |
-| **networkobservability_tcp_flag_counters**     | TCP packet count by flag | `flag` | ❌ | ✅ |
-| **networkobservability_ip_connection_stats**   | IP connection statistics | `statistic` | ✅ | ❌ |
-| **networkobservability_udp_connection_stats**  | UDP connection statistics | `statistic` | ✅ | ❌ |
-| **networkobservability_udp_active_sockets**    | UDP active socket count |  | ✅ | ❌ |
-| **networkobservability_interface_stats**       | Interface statistics | InterfaceName, `statistic` | ✅ | ✅ |
+| Metric name | Description | Extra labels | Linux | Windows |
+|-------------|-------------|--------------|-------|---------|
+| **networkobservability_conntrack_bytes_rx** | Conntrack RX byte count | | ✅ | ❌ |
+| **networkobservability_conntrack_bytes_tx** | Conntrack TX byte count | | ✅ | ❌ |
+| **networkobservability_conntrack_packets_rx** | Conntrack RX packet count | | ✅ | ❌ |
+| **networkobservability_conntrack_packets_tx** | Conntrack TX packet count | | ✅ | ❌ |
+| **networkobservability_conntrack_total_connections** | Total conntrack connections | | ✅ | ❌ |
+| **networkobservability_dns_request_count** | DNS request count | | ✅ | ❌ |
+| **networkobservability_dns_response_count** | DNS response count | | ✅ | ❌ |
+| **networkobservability_drop_bytes** | Total dropped byte count | `reason`, `direction` | ✅ | ❌ |
+| **networkobservability_drop_count** | Total dropped packet count | `reason`, `direction` | ✅ | ✅ |
+| **networkobservability_forward_bytes** | Total forwarded byte count | `direction` | ✅ | ✅ |
+| **networkobservability_forward_count** | Total forwarded packet count | `direction` | ✅ | ✅ |
+| **networkobservability_infiniband_counter_stats** | InfiniBand counter statistics | `statistic_name`, `device`, `port` | ✅ | ❌ |
+| **networkobservability_infiniband_status_params** | InfiniBand status parameters | `statistic_name`, `interface_name` | ✅ | ❌ |
+| **networkobservability_interface_stats** | Interface statistics (rx/tx packets, drops, etc.) | `interface_name`, `statistic_name` | ✅ | ❌ |
+| **networkobservability_ip_connection_stats** | IP connection statistics | `statistic_name` | ✅ | ❌ |
+| **networkobservability_node_apiserver_handshake_latency** | TCP handshake latency to API server | | ✅ | ❌ |
+| **networkobservability_node_apiserver_latency** | Node to API server latency | | ✅ | ❌ |
+| **networkobservability_node_apiserver_no_response** | No response from API server count | | ✅ | ❌ |
+| **networkobservability_node_connectivity_latency_seconds** | Node-to-node connectivity latency | `source_node_name`, `target_node_name` | ✅ | ✅ |
+| **networkobservability_node_connectivity_status** | Node-to-node connectivity status (ICMP/HTTP) | `source_node_name`, `target_node_name` | ✅ | ✅ |
+| **networkobservability_tcp_connection_remote** | TCP active socket count by remote IP | `address` | ✅ | ❌ |
+| **networkobservability_tcp_connection_stats** | TCP connection statistics (e.g., DelayedACKs, TCPKeepAlive, TCPSackFailures) | `statistic_name` | ✅ | ✅ |
+| **networkobservability_tcp_flag_gauges** | TCP packet counts by flag | `direction`, `flag` | ❌ | ✅ |
+| **networkobservability_tcp_retransmission_count** | TCP retransmission count | | ✅ | ❌ |
+| **networkobservability_tcp_state** | TCP active socket count by state | `state` | ✅ | ❌ |
+| **networkobservability_udp_connection_stats** | UDP connection statistics | `statistic_name` | ✅ | ❌ |
+| **networkobservability_windows_hns_stats** | Windows HNS statistics (packets sent/received) | `direction` | ❌ | ✅ |
 
 ---
 

--- a/articles/aks/monitor-aks.md
+++ b/articles/aks/monitor-aks.md
@@ -621,26 +621,41 @@ Cilium exposes several metrics that Container Network Observability uses:
 
 #### [Non-Cilium](#tab/non-cilium)
 
-> **OS support and known limitations**: For non-Cilium data plane scenarios, Container Network Observability provides metrics for both Linux and Windows operating systems. However, due to an identified bug, TCP resets temporarily aren't visible, so the `networkobservability_tcp_flag_counters` metrics aren't published for Linux nodes. We're actively working to resolve this issue.
+> **OS support and known limitations**: For non-Cilium data plane scenarios, Container Network Observability provides metrics for both Linux and Windows operating systems.
 
 For non-Cilium data plane scenarios, Container Network Observability provides metrics for both Linux and Windows operating systems.
 
-The following table outlines the generated metrics:
+The following table outlines the generated metrics. For the complete and up-to-date list, see [Container network metrics](container-network-observability-metrics.md).
 
 | Metric name | Description | Extra labels | Linux | Windows |
-| ----------- | ----------- | ------------ | ----- | ------- |
-| `networkobservability_forward_count` | Total forwarded packet count | `direction` | Supported ✅ | Supported ✅ |
+|-------------|-------------|--------------|-------|---------|
+| `networkobservability_conntrack_bytes_rx` | Conntrack RX byte count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_conntrack_bytes_tx` | Conntrack TX byte count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_conntrack_packets_rx` | Conntrack RX packet count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_conntrack_packets_tx` | Conntrack TX packet count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_conntrack_total_connections` | Total conntrack connections | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_dns_request_count` | DNS request count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_dns_response_count` | DNS response count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_drop_bytes` | Total dropped byte count | `reason`, `direction` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_drop_count` | Total dropped packet count | `reason`, `direction` | Supported ✅ | Supported ✅ |
 | `networkobservability_forward_bytes` | Total forwarded byte count | `direction` | Supported ✅ | Supported ✅ |
-| `networkobservability_drop_count` | Total dropped packet count | `direction`, `reason` | Supported ✅ | Supported ✅ |
-| `networkobservability_drop_bytes` | Total dropped byte count | `direction`, `reason` | Supported ✅ | Supported ✅ |
-| `networkobservability_tcp_state` | TCP currently active socket count by TCP state | `state` | Supported ✅ | Supported ✅ |
-| `networkobservability_tcp_connection_remote` | TCP currently active socket count by remote IP/port | `address` (IP), `port` | Supported ✅ | Unsupported ❌ |
-| `networkobservability_tcp_connection_stats` | TCP connection statistics (example: Delayed ACKs, TCPKeepAlive, TCPSackFailures) | `statistic` | Supported ✅ | Supported ✅ |
-| `networkobservability_tcp_flag_counters` | TCP packets count by flag | `flag` | Unsupported ❌ | Supported ✅ |
-| `networkobservability_ip_connection_stats` | IP connection statistics | `statistic` | Supported ✅ | Unsupported ❌ |
-| `networkobservability_udp_connection_stats` | UDP connection statistics | `statistic` | Supported ✅ | Unsupported ❌ |
-| `networkobservability_udp_active_sockets` | UDP currently active socket count | N/A | Supported ✅ | Unsupported ❌ |
-| `networkobservability_interface_stats` | Interface statistics | InterfaceName, `statistic` | Supported ✅ | Supported ✅ |
+| `networkobservability_forward_count` | Total forwarded packet count | `direction` | Supported ✅ | Supported ✅ |
+| `networkobservability_infiniband_counter_stats` | InfiniBand counter statistics | `statistic_name`, `device`, `port` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_infiniband_status_params` | InfiniBand status parameters | `statistic_name`, `interface_name` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_interface_stats` | Interface statistics (rx/tx packets, drops, etc.) | `interface_name`, `statistic_name` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_ip_connection_stats` | IP connection statistics | `statistic_name` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_node_apiserver_handshake_latency` | TCP handshake latency to API server | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_node_apiserver_latency` | Node to API server latency | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_node_apiserver_no_response` | No response from API server count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_node_connectivity_latency_seconds` | Node-to-node connectivity latency | `source_node_name`, `target_node_name` | Supported ✅ | Supported ✅ |
+| `networkobservability_node_connectivity_status` | Node-to-node connectivity status (ICMP/HTTP) | `source_node_name`, `target_node_name` | Supported ✅ | Supported ✅ |
+| `networkobservability_tcp_connection_remote` | TCP active socket count by remote IP | `address` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_tcp_connection_stats` | TCP connection statistics (e.g., DelayedACKs, TCPKeepAlive, TCPSackFailures) | `statistic_name` | Supported ✅ | Supported ✅ |
+| `networkobservability_tcp_flag_gauges` | TCP packet counts by flag | `direction`, `flag` | Unsupported ❌ | Supported ✅ |
+| `networkobservability_tcp_retransmission_count` | TCP retransmission count | | Supported ✅ | Unsupported ❌ |
+| `networkobservability_tcp_state` | TCP active socket count by state | `state` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_udp_connection_stats` | UDP connection statistics | `statistic_name` | Supported ✅ | Unsupported ❌ |
+| `networkobservability_windows_hns_stats` | Windows HNS statistics (packets sent/received) | `direction` | Unsupported ❌ | Supported ✅ |
 
 ---
 

--- a/articles/aks/monitor-aks.md
+++ b/articles/aks/monitor-aks.md
@@ -8,6 +8,7 @@ ms.service: azure-kubernetes-service
 author: davidsmatlak
 ms.author: davidsmatlak
 ms.subservice: aks-monitoring
+ai-usage: ai-assisted
 #Customer intent: As a cloud administrator, I want to implement comprehensive monitoring for Azure Kubernetes Service (AKS) so that I can ensure performance and reliability in my critical applications and manage resource utilization effectively.
 ---
 
@@ -621,9 +622,7 @@ Cilium exposes several metrics that Container Network Observability uses:
 
 #### [Non-Cilium](#tab/non-cilium)
 
-> **OS support and known limitations**: For non-Cilium data plane scenarios, Container Network Observability provides metrics for both Linux and Windows operating systems.
-
-For non-Cilium data plane scenarios, Container Network Observability provides metrics for both Linux and Windows operating systems.
+> **OS support**: For non-Cilium data plane scenarios, Container Network Observability provides metrics for both Linux and Windows operating systems.
 
 The following table outlines the generated metrics. For the complete and up-to-date list, see [Container network metrics](container-network-observability-metrics.md).
 


### PR DESCRIPTION
## Summary

Updates the non-Cilium (Microsoft Retina) container network metrics tables to match the
metrics actually emitted by the current Retina agent. Verified against the Retina source
(`pkg/utils/metric_names.go`, `pkg/utils/attr_utils.go`, `pkg/metrics/metrics.go`, and the
plugin implementations).

Documentation-only change; no product/behavior changes.

## Files changed

- `articles/aks/container-network-observability-metrics.md` — non-Cilium node-level metrics table
- `articles/aks/monitor-aks.md` — non-Cilium metrics table under **AKS node network metrics by data plane type**

## What changed

- **Removed the stale "TCP resets bug" note** — `networkobservability_tcp_flag_counters`
  no longer exists; it was renamed.
- **Renamed metrics/labels to match current output:**
  - `tcp_flag_counters` → `tcp_flag_gauges` (labels `direction`, `flag`)
  - `udp_active_sockets` removed (folded into `udp_connection_stats`)
  - Label renames: `statistic` → `statistic_name`, `InterfaceName` → `interface_name`,
    `tcp_connection_remote` now uses `address` (no separate `port`)
- **Added newly available metrics:** `conntrack_*`, `dns_request_count`,
  `dns_response_count`, `infiniband_counter_stats`, `infiniband_status_params`,
  `node_apiserver_latency`, `node_apiserver_handshake_latency`,
  `node_apiserver_no_response`, `node_connectivity_status`,
  `node_connectivity_latency_seconds`, `tcp_retransmission_count`, `windows_hns_stats`.
- **Corrected OS support:** `tcp_state` and `drop_bytes` are Linux-only; `drop_count`,
  `forward_*`, and `windows_hns_stats` reflect actual Windows support.

## Validation

- Metric names, labels, and Linux/Windows support cross-checked against the Retina codebase.
- Tables in both files are kept consistent with each other.