### PR TITLE
Fix private Fleet hub creation command

### DIFF
--- a/articles/kubernetes-fleet/quickstart-create-fleet-and-members.md
+++ b/articles/kubernetes-fleet/quickstart-create-fleet-and-members.md
@@ -3,7 +3,7 @@ title: "Quickstart: Create an Azure Kubernetes Fleet Manager and join member clu
 description: In this quickstart, you learn how to create an Azure Kubernetes Fleet Manager and join member clusters using Azure CLI.
 author: sjwaight
 ms.author: simonwaight
-ms.date: 06/01/2026
+ms.date: 07/24/2026
 ms.service: azure-kubernetes-fleet-manager
 ms.topic: quickstart
 ms.custom:
@@ -219,12 +219,14 @@ API_SUBNET_ID=$(az network vnet subnet show --resource-group ${GROUP} --vnet-nam
 6. Finally, create the new hub cluster, providing the necessary arguments to enable API VNet integration  
 
 ```azurecli-interactive
- az fleet create \
+az fleet create \
     --resource-group ${GROUP} \
     --name ${FLEET} \
     --location ${LOCATION}  \
     --enable-hub \
     --enable-managed-identity \
+    --enable-private-cluster \
+    --enable-vnet-integration \
     --agent-subnet-id ${CLUSTER_SUBNET_ID} \
     --apiserver-subnet-id ${API_SUBNET_ID} \
     --assign-identity ${UAMI_ID}


### PR DESCRIPTION
## Description

Adds the flags required to create the documented private Fleet hub with API Server VNet Integration:

- `--enable-private-cluster`
- `--enable-vnet-integration`

Without the first flag, the command fails with `AgentSubnetUnsupported` because the Fleet defaults to public networking. Adding only that flag exposes a second `APIServerSubnetUnsupported` failure because an API server subnet requires VNet integration to be enabled.

## Validation

Reproduced both failures in the AKS Fleet Development/Test subscription, then verified the corrected command provisions successfully with private cluster and VNet integration enabled.