### PR TITLE
Move AKS disconnected operations to a top-level Azure Local deployment mode

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -84,6 +84,11 @@
       "source_path_from_root": "/articles/aks/deploy-ray-tuning.md",
       "redirect_url": "/azure/aks/ray-overview",
       "redirect_document_id": false
+    },
+    {
+      "source_path": "articles/aks-hybrid-edge/local/hyperconverged/disconnected-operations-aks.md",
+      "redirect_url": "/azure/aks-hybrid-edge/local/disconnected-operations/overview",
+      "redirect_document_id": false
     }
   ]
 }

--- a/articles/aks-hybrid-edge/TOC.yml
+++ b/articles/aks-hybrid-edge/TOC.yml
@@ -178,8 +178,6 @@
           href: local/hyperconverged/get-on-demand-logs.md
         - name: Monitoring data reference
           href: local/hyperconverged/kubernetes-monitor-metrics.md
-      - name: AKS disconnected operations
-        href: local/hyperconverged/disconnected-operations-aks.md
       - name: Use autoscaler
         href: local/hyperconverged/auto-scale-aks-arc.md
       - name: Upgrade Kubernetes clusters
@@ -309,6 +307,12 @@
         href: ./local/multi-rack/aks-customer-proxy.md
       - name: Upgrade Kubernetes cluster
         href: ./local/multi-rack/cluster-upgrade.md
+  - name: Disconnected operations
+    items:
+    - name: Overview
+      href: local/disconnected-operations/overview.md
+    - name: Create and manage a cluster
+      href: local/disconnected-operations/create-manage-cluster.md
 - name: AKS Edge Essentials
   items:
   - name: Overview

--- a/articles/aks-hybrid-edge/local/disconnected-operations/create-manage-cluster.md
+++ b/articles/aks-hybrid-edge/local/disconnected-operations/create-manage-cluster.md
@@ -1,47 +1,21 @@
 ---
-title: Manage AKS for Azure Local with disconnected operations (preview)
-description: Manage Azure Kubernetes Service (AKS) Arc for Azure Local with disconnected operations (preview).
+title: Create and manage an AKS cluster with disconnected operations (preview)
+description: Learn how to create and manage an Azure Kubernetes Service (AKS) cluster enabled by Azure Arc for Azure Local with disconnected operations (preview).
 ms.topic: how-to
 author: davidsmatlak
 ms.author: davidsmatlak
 ms.date: 09/01/2026
-ms.custom: hyperconverged
+ms.custom: disconnected-operations
 ai-usage: ai-assisted
 ---
 
-# Manage AKS for Azure Local with disconnected operations (preview)
+# Create and manage an AKS cluster with disconnected operations (preview)
 
-This article gives you an overview of Azure Kubernetes Service (AKS) Arc for disconnected operations for Azure Local (preview). It closely mirrors AKS capabilities on Azure Local and includes many references to Azure Local AKS articles. You learn how to deploy and manage AKS clusters in disconnected environments, understand key differences, and review limitations to ensure successful implementation.
+This article shows you how to install the required Azure CLI extensions, create logical networks, and create, access, and delete an Azure Kubernetes Service (AKS) cluster enabled by Azure Arc for Azure Local with disconnected operations (preview).
 
 [!INCLUDE [IMPORTANT](../../includes/aks-disconnected-operations-preview.md)]
 
-## Overview
-
-AKS for disconnected operations allows you to manage Kubernetes clusters and deploy applications across various environments using disconnected operations. This capability ensures you can maintain consistent management and operational experience of AKS on Azure Local using a local control plane.
-
-## Prerequisites
-
-- [Azure Command-Line Interface (CLI)](/azure/azure-local/manage/disconnected-operations-cli) installed on your local machine.
-- An Azure subscription associated with disconnected operations.
-- Understanding of AKS and Azure Arc concepts.
-- Complete [Identity for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-identity).
-- Complete [Networking for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-network).
-- Complete [Public key infrastructure (PKI) for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-pki).
-- Complete [Hardware for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-overview#eligibility-criteria).
-- Complete [Set up for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-set-up).
-
-## Limitations
-
-Limitations for disconnected operations with AKS include:
-
-- Support for disconnected operations begins with the 2408 release.
-- Supported Kubernetes versions: 1.33.4 and 1.33.5.
-- Windows node pools aren't supported.
-- Microsoft Entra ID (formerly Azure Active Directory) isn't supported for disconnected operations.
-- GPUs aren't supported.
-- Arc Gateway isn't supported for configuring outbound URLs.
-- Create logical networks using the CLI only. The portal isn't supported.
-- Create SSH keys using the CLI only. The portal isn't supported.
+Before you continue, review the [prerequisites and limitations](overview.md) for AKS with disconnected operations.
 
 ## Create an AKS cluster
 
@@ -57,7 +31,7 @@ Before you install the Azure CLI extension, make sure you have the following ins
   - aksarc: 1.2.23
   - stack-hci-vm: 1.11.1
 
-Install the CLI extension using the following commands:
+Install the CLI extension by using the following commands:
 
 ```azurecli
 az extension add --name aksarc --version 1.2.23 
@@ -69,11 +43,11 @@ For more information, see [Install the Azure CLI extension](../aks-create-cluste
 
 ### Sign in with Azure CLI
 
-You can use the `az login` command to sign in to your Azure account. For more information, see [Sign in with credentials on the command line](/cli/azure/authenticate-azure-cli-interactively#sign-in-with-credentials-on-the-command-line).
+Use the `az login` command to sign in to your Azure account. For more information, see [Sign in with credentials on the command line](/cli/azure/authenticate-azure-cli-interactively#sign-in-with-credentials-on-the-command-line).
 
 ### Create logical networks
 
-Use the [`az stack-hci-vm network lnet create`](/cli/azure/stack-hci-vm/network/lnet#az-stack-hci-vm-network-lnet-create) command to create a logical network on the virtual machine (VM) switch in Static IP configuration. For information on limitations, see [Limitations](#limitations).
+Use the [`az stack-hci-vm network lnet create`](/cli/azure/stack-hci-vm/network/lnet#az-stack-hci-vm-network-lnet-create) command to create a logical network on the virtual machine (VM) switch in Static IP configuration. For information on limitations, see [Limitations](overview.md#limitations).
 
 ```azurecli
 az stack-hci-vm network lnet create \
@@ -90,14 +64,14 @@ az stack-hci-vm network lnet create \
   --ip-pool-end $ipPoolEnd
 ```
 
-For more information, see [Create logical networks](aks-networks.md).
+For more information, see [Create logical networks](../hyperconverged/aks-networks.md).
 
 > [!NOTE]
-> Logical networks are created through CLI only; the portal isn't supported. For more information, see [Azure Local VM limitations](/azure/azure-local/manage/disconnected-operations-arc-vm#limitations).
+> You can create logical networks only through CLI. The portal isn't supported. For more information, see [Azure Local VM limitations](/azure/azure-local/manage/disconnected-operations-arc-vm#limitations).
 
 ### Create the cluster
 
-To create the AKS cluster, we recommend you use CLI. For more information, see [Create an AKS cluster through CLI](../aks-create-clusters-cli.md#create-a-kubernetes-cluster).
+Use CLI to create the AKS cluster. For more information, see [Create an AKS cluster through CLI](../aks-create-clusters-cli.md#create-a-kubernetes-cluster).
 
 To use the Azure portal, see [Create a Kubernetes cluster using the Azure portal](../aks-create-clusters-portal.md#create-a-kubernetes-cluster). To create the SSH keys, see [Generate and store SSH keys with the Azure CLI](/azure/virtual-machines/ssh-keys-azure-cli).
 
@@ -113,9 +87,9 @@ az aksarc create \
 ```
 
 > [!NOTE]
-> You should get JSON formatted information about the cluster once the creation is complete.
+> You receive JSON-formatted information about the cluster when the creation finishes.
 
-Here's an example script to create logical networks and an AKS cluster.
+Here's a sample script to create logical networks and an AKS cluster.
 
 ```azurecli
 # Check and update variables according to your environment.
@@ -171,7 +145,7 @@ az aksarc create -n $aksClusterName `
 
 ### Retrieve `kubeconfig`
 
-To retrieve the `kubeconfig` file for the AKS cluster, use the [`az aksarc get-credentials`](/cli/azure/aksarc#az-aksarc-get-credentials) command. Make sure you use your admin credentials.
+To retrieve the `kubeconfig` file for the AKS cluster, use the [`az aksarc get-credentials`](/cli/azure/aksarc#az-aksarc-get-credentials) command. Use your admin credentials.
 
 Here's an example:
 
@@ -192,11 +166,11 @@ az aksarc get-credentials \
   --kubeconfig C:\AksArc\config-admin get ns  
 ```
 
-For more information, see [Retrieve kubeconfig](retrieve-admin-kubeconfig.md#retrieve-the-certificate-based-admin-kubeconfig-using-az-cli).
+For more information, see [Retrieve kubeconfig](../hyperconverged/retrieve-admin-kubeconfig.md#retrieve-the-certificate-based-admin-kubeconfig-using-az-cli).
 
 ### Delete an AKS cluster
 
-You can use the [`az aksarc delete`](/cli/azure/aksarc#az-aksarc-delete) command to delete the AKS cluster you created.
+Use the [`az aksarc delete`](/cli/azure/aksarc#az-aksarc-delete) command to delete the AKS cluster you created.
 
 ```azurecli
 az aksarc delete --name $aksclustername --resource-group $resource_group
@@ -204,7 +178,8 @@ az aksarc delete --name $aksclustername --resource-group $resource_group
 
 ## Related content
 
-- [AKS on Azure Local architecture](cluster-architecture.md)
-- [AKS Hybrid and Edge network requirements](network-system-requirements.md)
-- [Manage node pools for an AKS cluster](manage-node-pools.md)
-- [Use cluster autoscaler on an AKS arc cluster](auto-scale-aks-arc.md)
+- [AKS on Azure Local with disconnected operations (preview)](overview.md)
+- [AKS on Azure Local architecture](../hyperconverged/cluster-architecture.md)
+- [AKS Hybrid and Edge network requirements](../hyperconverged/network-system-requirements.md)
+- [Manage node pools for an AKS cluster](../hyperconverged/manage-node-pools.md)
+- [Use cluster autoscaler on an AKS arc cluster](../hyperconverged/auto-scale-aks-arc.md)

--- a/articles/aks-hybrid-edge/local/disconnected-operations/overview.md
+++ b/articles/aks-hybrid-edge/local/disconnected-operations/overview.md
@@ -1,0 +1,61 @@
+---
+title: AKS on Azure Local with disconnected operations (preview)
+description: Learn about Azure Kubernetes Service (AKS) enabled by Azure Arc for Azure Local with disconnected operations (preview), including supported scenarios, prerequisites, and limitations.
+ms.topic: overview
+author: davidsmatlak
+ms.author: davidsmatlak
+ms.date: 09/01/2026
+ms.custom: disconnected-operations
+ai-usage: ai-assisted
+---
+
+# AKS on Azure Local with disconnected operations (preview)
+
+[!INCLUDE [IMPORTANT](../../includes/aks-disconnected-operations-preview.md)]
+
+[Disconnected operations](/azure/azure-local/manage/disconnected-operations-overview) is an Azure Local capability that you use to deploy and manage Azure Local instances without a connection to the Azure public cloud. Use select Azure Arc-enabled services from a local control plane. Azure Kubernetes Service (AKS) enabled by Azure Arc is one of the services supported for disconnected operations. You get the same familiar Azure portal, Azure CLI, and Azure Resource Manager experience for creating and managing Kubernetes clusters, entirely from the local control plane.
+
+> [!NOTE]
+> Disconnected operations is a distinct Azure Local deployment mode with its own local control plane and hardware requirements. It's not the same as the [connectivity modes](../hyperconverged/connectivity-modes.md) that describe how a standard, cloud-connected AKS on Azure Local cluster behaves during a temporary loss of connectivity to Azure.
+
+## Why use disconnected operations for AKS
+
+Use disconnected operations for AKS on Azure Local for scenarios such as:
+
+- **Sovereign requirements and compliance**: Sectors like government, healthcare, and finance often have data residency and sovereignty requirements that are hard to meet by using public sovereign cloud controls. Running disconnected keeps data, operations, and control within your organization's boundaries.
+- **Remote or isolated locations**: Sites with limited or no network infrastructure, such as oil rigs or manufacturing floors, can still get an Azure portal and Azure CLI experience for managing Kubernetes clusters without relying on internet connectivity.
+- **Security**: Industries with strict security requirements can reduce their attack surface by not exposing systems to external networks.
+
+## How it works
+
+AKS for disconnected operations closely mirrors AKS capabilities on Azure Local: you use the same Azure CLI extensions and largely the same commands to create logical networks, create and manage Kubernetes clusters, and retrieve `kubeconfig` files. The key difference is that the local control plane serves all these operations instead of the Azure public cloud. You maintain a consistent management and operational experience even without internet connectivity.
+
+## Prerequisites
+
+- [Azure Command-Line Interface (CLI)](/azure/azure-local/manage/disconnected-operations-cli) installed on your local machine.
+- An Azure subscription associated with disconnected operations.
+- Understanding of AKS and Azure Arc concepts.
+- Complete [Identity for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-identity).
+- Complete [Networking for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-network).
+- Complete [Public key infrastructure (PKI) for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-pki).
+- Complete [Hardware for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-overview#eligibility-criteria).
+- Complete [Set up for Azure Local with disconnected operations](/azure/azure-local/manage/disconnected-operations-set-up).
+
+## Limitations
+
+Limitations for disconnected operations with AKS include:
+
+- Support for disconnected operations begins with the 2408 release.
+- Supported Kubernetes versions: 1.33.4 and 1.33.5.
+- Windows node pools aren't supported.
+- Microsoft Entra ID (formerly Azure Active Directory) isn't supported for disconnected operations.
+- GPUs aren't supported.
+- Arc Gateway isn't supported for configuring outbound URLs.
+- Create logical networks by using the CLI only. The portal isn't supported.
+- Create SSH keys by using the CLI only. The portal isn't supported.
+
+## Related content
+
+- [Create and manage an AKS cluster with disconnected operations](create-manage-cluster.md)
+- [What is AKS on Azure Local?](../aks-local-overview.md)
+- [Connectivity modes in AKS on Azure Local](../hyperconverged/connectivity-modes.md)

--- a/articles/aks-hybrid-edge/local/hyperconverged/connectivity-modes.md
+++ b/articles/aks-hybrid-edge/local/hyperconverged/connectivity-modes.md
@@ -13,6 +13,9 @@ ms.custom: conceptual, hyperconverged
 
 # Connectivity modes in AKS on Azure Local
 
+> [!NOTE]
+> This article describes the connectivity states of a standard, cloud-connected AKS on Azure Local cluster. It's not the same as [disconnected operations](../disconnected-operations/overview.md), which is a distinct Azure Local deployment mode with its own local control plane for running AKS without any connection to the Azure public cloud.
+
 AKS on Azure Local requires connectivity to Azure in order to use features such as Kubernetes cluster upgrades, and identity and access options such as Azure Entra ID. Also, Azure Arc agents on the AKS cluster must remain connected to enable functionality such as [configuring (GitOps)](/azure/azure-arc/kubernetes/conceptual-gitops-flux2), Arc extensions, and [cluster connect](/azure/azure-arc/kubernetes/conceptual-cluster-connect). Since AKS on Azure Local clusters deployed at the edge might not always have stable network access, the Kubernetes cluster might occasionally be unable to reach Azure when it operates in a semi-connected state.
 
 ## Understand connectivity modes


### PR DESCRIPTION
## Summary

The AKS disconnected operations article was previously nested three levels deep under **AKS on Azure Local > Hyperconverged > How-to**, as a peer to task articles like "Manage node pools." It was tagged `ms.topic: how-to` but actually mixed overview/concept content (overview, prerequisites, limitations) with task steps.

Disconnected operations is really a distinct Azure Local deployment mode (its own local control plane and hardware requirements), conceptually parallel to Hyperconverged and Multi-rack, not a Hyperconverged sub-feature. This PR promotes it to a top-level TOC node and splits the content by topic type.

## Changes

- Added `articles/aks-hybrid-edge/local/disconnected-operations/overview.md` (`ms.topic: overview`): what disconnected operations is, why to use it, how it works, prerequisites, and limitations.
- Renamed the CLI walkthrough to `articles/aks-hybrid-edge/local/disconnected-operations/create-manage-cluster.md` (`ms.topic: how-to`): install the CLI extension, create logical networks, create/access/delete a cluster.
- Updated `TOC.yml`: removed the old nested entry under Hyperconverged > How-to, added a new top-level Disconnected operations node (sibling of Hyperconverged and Multi-rack) with Overview and Create-and-manage-a-cluster entries.
- Added a redirect in `.openpublishing.redirection.json` from the old path to the new overview page.
- Added a disambiguation note (and cross-link) between the new overview and `connectivity-modes.md`, since both use the word "disconnected" but describe different things: disconnected operations is a distinct deployment mode with a local control plane, while connectivity modes describe a standard cloud-connected cluster's behavior during a temporary loss of connectivity.

## Testing

- Validated `.openpublishing.redirection.json` (JSON) and `TOC.yml` (YAML) parse correctly.
- Grepped the repo for any remaining references to the old file path, none found.
- Manually reviewed rendered content for both new articles.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
